### PR TITLE
[EIJ-8] Allow ability to change name

### DIFF
--- a/client/components/game/name.js
+++ b/client/components/game/name.js
@@ -2,22 +2,40 @@
 
 import React from 'react';
 
+import socket from '../../socket';
+
 import styles from './name.scss';
 
 type Props = {|
   value: string
 |};
 
-const Name = ({value}: Props) => (
-  <div className={styles.name}>
-    <p>You are</p>
-    <p
-      className={styles.text}
-      data-type="name"
-    >
-      {value}
-    </p>
-  </div>
-);
+class Name extends React.Component<Props> {
+  handleChange = (e: SyntheticInputEvent<HTMLInputElement>) => {
+    const {
+      target: {
+        value: name
+      }
+    } = e;
+
+    socket.emit('updatePlayer', {name});
+  }
+
+  render() {
+    const {value} = this.props;
+
+    return (
+      <div className={styles.name}>
+        <p>You are</p>
+        <input
+          className={styles.text}
+          data-type="name"
+          defaultValue={value}
+          onChange={this.handleChange}
+        />
+      </div>
+    );
+  }
+}
 
 export default Name;

--- a/client/components/game/name.scss
+++ b/client/components/game/name.scss
@@ -4,5 +4,17 @@
 
   .text {
     font-weight: bold;
+    font-size: 0.75em;
+    border: 0;
+    border-bottom: 1px solid #333;
+    width: 500px;
+
+    &:focus {
+        outline: none;
+    }
+
+    @media screen and (max-width: 500px) {
+        width: 100%;
+    }
   }
 }

--- a/test/client/components/game/name.test.js
+++ b/test/client/components/game/name.test.js
@@ -1,8 +1,14 @@
 import test from 'ava';
 import React from 'react';
+import proxyquire from 'proxyquire';
 import {shallow} from 'enzyme';
+import {MockSocket} from '../../../server/mocks/socket';
 
-import Name from '../../../../client/components/game/name';
+const socket = new MockSocket();
+
+const Name = proxyquire('../../../../client/components/game/name', {
+  '../../socket': {default: socket}
+}).default;
 
 const render = (props = {}) => shallow(<Name {...props}/>);
 
@@ -10,8 +16,20 @@ test('it renders the players name', t => {
   const value = 'Joe';
   const wrapper = render({value});
 
-  const name = wrapper.find('[data-type="name"]');
+  const name = wrapper.find('input[data-type="name"]');
 
   t.is(name.length, 1);
-  t.is(name.text(), value);
+  t.is(name.props().defaultValue, value);
+});
+
+test('it updates the name on change', t => {
+  const value = 'new value';
+  const wrapper = render({value: 'Joe'});
+  const name = wrapper.find('input[data-type="name"]');
+
+  name.simulate('change', {target: {value}});
+
+  t.true(socket.emit.calledWith('updatePlayer', {
+    name: value
+  }));
 });


### PR DESCRIPTION
https://jira.kolya.cloud/browse/EIJ-8

- Makes the client `Name` component a text box, that emits the new name to the server