### PR TITLE
[EIJ-22] Fix bug where GM was destroyed upon reload

### DIFF
--- a/client/socket/actions/update-player.js
+++ b/client/socket/actions/update-player.js
@@ -15,12 +15,30 @@ type Payload = {|
   frozen: boolean
 |};
 
+const shouldUpdateId = (payload: Payload): boolean => {
+  const {id} = payload;
+  const {
+    player: {id: playerId},
+    game: {isGm}
+  } = store.getState();
+
+  if (id && !isGm) {
+    if (playerId === id) {
+      return false;
+    }
+
+    return true;
+  }
+
+  return false;
+};
+
 const setPlayerInfo = (payload: Payload) => {
   const {game} = store.getState();
 
   const type = game.isGm ? 'SET_GAME_PLAYER_INFO' : 'SET_PLAYER_INFO';
 
-  if (payload.id) {
+  if (shouldUpdateId(payload)) {
     set(EIJ_PID, payload.id);
   }
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "author": "",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/kolyaventuri/everyoneisjohn/issues"
+    "url": "https://jira.kolya.cloud/projects/EIJ/issues"
   },
   "homepage": "https://github.com/kolyaventuri/everyoneisjohn#readme",
   "devDependencies": {

--- a/server/lib/logger.js
+++ b/server/lib/logger.js
@@ -1,0 +1,7 @@
+// @flow
+
+import Logger from 'scriba';
+
+const logger = new Logger({scope: 'SERVER'});
+
+export const {logInfo, logError} = logger;

--- a/server/lib/logger.js
+++ b/server/lib/logger.js
@@ -4,4 +4,10 @@ import Logger from 'scriba';
 
 const logger = new Logger({scope: 'SERVER'});
 
+if (process.env.NODE_ENV === 'test') {
+  const noop = () => {};
+  logger.logInfo = noop;
+  logger.logError = noop;
+}
+
 export const {logInfo, logError} = logger;

--- a/server/models/game.js
+++ b/server/models/game.js
@@ -2,6 +2,7 @@
 
 import Chance from 'chance';
 
+import {logInfo} from '../lib/logger';
 import Slug from '../lib/slug';
 import * as GameModes from '../lib/game-mode';
 import {gameRepository, playerRepository} from '../repositories';
@@ -66,6 +67,8 @@ export default class Game {
     if (init) {
       this.gmInitGame();
     }
+
+    logInfo(`Game ${id} created by player ${owner.id}`);
   }
 
   addPlayer(player: Player) {
@@ -74,6 +77,7 @@ export default class Game {
 
     if (!players.includes(id)) {
       players.push(id);
+      logInfo(`Player ${player.id} added to Game ${this.id}`);
       player.setGame(this);
     }
 
@@ -88,6 +92,7 @@ export default class Game {
   }
 
   gmInitGame() {
+    logInfo(`Player ${this.owner.id} init as GM for game ${this.id}`);
     const {prefix} = this.__STATICS__;
     this.owner.setGame(this);
 
@@ -121,6 +126,7 @@ export default class Game {
   }
 
   destroy() {
+    logInfo(`Game ${this.id} is being destroyed!`);
     gameRepository.destroy(this);
   }
 

--- a/server/models/player.js
+++ b/server/models/player.js
@@ -3,6 +3,7 @@
 import uuid from 'uuid/v1';
 import Chance from 'chance';
 
+import {logInfo} from '../lib/logger';
 import {gameRepository, playerRepository} from '../repositories';
 import Game from './game';
 import Stats from './stats';
@@ -50,6 +51,8 @@ export default class Player {
 
     playerRepository.insert(this);
     this.destroyGame = this.destroyGame.bind(this);
+
+    logInfo(`Player ${name} (${id}) created`);
   }
 
   deactivate() {
@@ -79,6 +82,7 @@ export default class Player {
   }
 
   disconnect() {
+    logInfo(`Player ${this.id} disconnected.`);
     this.deactivate();
 
     this.__STATICS__.disconnectTimer = setTimeout(() => {
@@ -95,6 +99,7 @@ export default class Player {
   }
 
   destroy() {
+    logInfo(`Player ${this.id} is being destroyed!`);
     playerRepository.destroy(this);
   }
 

--- a/server/socket/actions/join-gm.js
+++ b/server/socket/actions/join-gm.js
@@ -2,15 +2,28 @@
 
 import type {SocketType} from '..';
 import {gameRepository} from '../../repositories';
+import {logInfo, logError} from '../../lib/logger';
 
 const joinGm = (socket: SocketType, gameId: string) => {
   const {player} = socket;
   const game = gameRepository.find(gameId);
 
-  if (game && game.owner === player) {
-    game.gmInitGame();
-    game.gmEmitPlayers();
-    return;
+  if (player) {
+    logInfo(`Player ${player.id} attempting to GM game ${gameId}`);
+  } else {
+    logError(`Unknown player attempting to GM game ${gameId}`);
+  }
+
+  if (game) {
+    if (game.owner === player) {
+      game.gmInitGame();
+      game.gmEmitPlayers();
+      return;
+    }
+
+    logError(`Owner mismatch for game ${gameId}.\nOwner: ${game.owner.id}\nPlayer: ${player.id}`);
+  } else {
+    logError(`Game ${gameId} not found`);
   }
 
   socket.emit('gameError', 'error.game.doesntExist');

--- a/test/client/socket/actions/update-player.test.js
+++ b/test/client/socket/actions/update-player.test.js
@@ -8,7 +8,8 @@ const set = stub();
 const state = {
   game: {
     isGm: false
-  }
+  },
+  player: {}
 };
 
 const store = {
@@ -43,6 +44,7 @@ test('it dispatches a SET_GAME_PLAYER_INFO action if the player is the GM', t =>
 });
 
 test('it stores the player ID on the localStorage object', t => {
+  state.game.isGm = false;
   const payload = {
     id: 'abcde'
   };
@@ -55,5 +57,18 @@ test('it stores the player ID on the localStorage object', t => {
 test('it does not attempt to store the player ID if it is not in the payload', t => {
   setPlayerInfo({});
 
-  t.false(set.calledTwice);
+  t.false(set.calledWith(EIJ_PID, undefined));
+});
+
+test('it does not attempt to store the player ID if the player is the GM, and the ID does not match their own', t => {
+  state.game.isGm = true;
+  state.player.id = 'my-id';
+
+  const payload = {
+    id: 'some-other-id'
+  };
+
+  setPlayerInfo(payload);
+
+  t.false(set.calledWith(EIJ_PID, payload.id));
 });


### PR DESCRIPTION
https://jira.kolya.cloud/browse/EIJ-22

- Fixes a bug where the GM would act like the game did not exist after a reconnect following any action
  - Turns out the issue was caused by setting the `localStorage.EIJ_PID` value when it should not have been modified, effectively impersonating a player.