### PR TITLE
[EIJ-19] Reset player stats upon joining game

### DIFF
--- a/server/models/player.js
+++ b/server/models/player.js
@@ -47,7 +47,7 @@ export default class Player {
       name
     };
 
-    this.stats = new Stats(this);
+    this.resetStats();
 
     playerRepository.insert(this);
     this.destroyGame = this.destroyGame.bind(this);
@@ -78,7 +78,18 @@ export default class Player {
   }
 
   setGame({id}: Game) {
+    const {game} = this;
+
+    if (game) {
+      this.leaveGame();
+      this.resetStats();
+    }
+
     this.__game = id;
+  }
+
+  resetStats() {
+    this.stats = new Stats(this);
   }
 
   disconnect() {

--- a/test/server/models/player.test.js
+++ b/test/server/models/player.test.js
@@ -250,3 +250,32 @@ test('emitUpdate is called when a player joins a game', t => {
 
   t.true(player.emitUpdate.called);
 });
+
+test('stats are destroyed upon joining new game', t => {
+  const {game, player} = setup();
+
+  game.addPlayer(player);
+  player.stats.willpower += 5;
+
+  const oldStats = Object.assign({}, player.serialize());
+
+  const {game: gameB} = setup();
+
+  gameB.addPlayer(player);
+
+  const newStats = Object.assign({}, player.serialize());
+
+  t.notDeepEqual(newStats, oldStats);
+});
+
+test('player is booted from the old game if they join a new one', t => {
+  const {game, player} = setup();
+
+  player.joinGame(game.id);
+
+  const {game: gameB} = setup();
+
+  player.joinGame(gameB.id);
+
+  t.true(player.leaveGame.called);
+});


### PR DESCRIPTION
https://jira.kolya.cloud/browse/EIJ-19

Ensures that...
- Player stats are reset when they join a new game
- Players are properly dropped from old game, if they change games