### PR TITLE
[EIJ-35] Allow skills to be deleted without overwriting others

### DIFF
--- a/client/components/game/goal.js
+++ b/client/components/game/goal.js
@@ -57,6 +57,7 @@ export default class Goal extends React.Component<Props> {
         placeholder="You must enter an obsession to play!"
         value={value}
         onInput={this.handleInput}
+        onChange={this.handleInput}
       />
     );
   }

--- a/client/components/game/skill-list.js
+++ b/client/components/game/skill-list.js
@@ -84,6 +84,7 @@ export default class SkillList extends React.Component<Props, State> {
           value={skill}
           placeholder="Enter a skill"
           onInput={e => this.handleInput(e, index)}
+          onChange={e => this.handleInput(e, index)}
         />
       </div>
     );

--- a/client/socket/actions/delete-item.js
+++ b/client/socket/actions/delete-item.js
@@ -1,0 +1,27 @@
+// @flow
+
+import {store} from '../../store';
+
+type Payload = {|
+  type: string,
+  index?: number
+|};
+
+const deleteItem = ({type, index}: Payload) => {
+  if (type === 'skill') {
+    const {
+      player: {skills}
+    } = store.getState();
+
+    skills[index] = '';
+
+    store.dispatch({
+      type: 'SET_PLAYER_INFO',
+      payload: {
+        skills
+      }
+    });
+  }
+};
+
+export default deleteItem;

--- a/client/socket/events.js
+++ b/client/socket/events.js
@@ -6,6 +6,7 @@ import gameJoinSuccess from './actions/game-join-success';
 import setGameMode from './actions/set-game-mode';
 import gameError from './actions/game-error';
 import disconnect from './actions/disconnect';
+import deleteItem from './actions/delete-item';
 
 import setPlayers from './actions/set-players';
 
@@ -17,6 +18,7 @@ const events = [
   {name: 'setGameMode', handler: setGameMode},
   {name: 'gameError', handler: gameError},
   {name: 'disconnect', handler: disconnect},
+  {name: 'deleteItem', handler: deleteItem},
 
   // GM Events
   {name: 'setPlayers', handler: setPlayers}

--- a/server/models/player.js
+++ b/server/models/player.js
@@ -162,6 +162,13 @@ export default class Player {
     }
   }
 
+  emitDelete({type, index}: {type: string, index?: number}) {
+    this.socket.emit('deleteItem', {
+      type,
+      index
+    });
+  }
+
   get id(): string {
     return this.__STATICS__.id;
   }

--- a/server/models/stats.js
+++ b/server/models/stats.js
@@ -136,7 +136,11 @@ export default class Stats {
   }
 
   deleteSkill(index: number) {
-    this.setSkill(index, '', true);
+    this.setSkill(index, '');
+    this.player.emitDelete({
+      type: 'skill',
+      index: index - 1
+    });
   }
 
   deleteGoal() {

--- a/test/client/socket/actions/delete-item.test.js
+++ b/test/client/socket/actions/delete-item.test.js
@@ -1,0 +1,39 @@
+import test from 'ava';
+import {stub} from 'sinon';
+import proxyquire from 'proxyquire';
+
+const dispatch = stub();
+const getState = stub();
+const store = {dispatch, getState};
+
+proxyquire.noCallThru();
+const deleteItem = proxyquire('../../../../client/socket/actions/delete-item', {
+  '../../store': {store}
+}).default;
+
+test('updates the redux store with the game', t => {
+  const payload = {
+    type: 'skill',
+    index: 1
+  };
+
+  const state = {
+    player: {
+      skills: ['a', 'b', 'c']
+    }
+  };
+
+  getState.returns(state);
+
+  const skills = [...(state.player.skills)];
+  skills[payload.index] = '';
+
+  deleteItem(payload);
+
+  t.true(dispatch.calledWith({
+    type: 'SET_PLAYER_INFO',
+    payload: {
+      skills
+    }
+  }));
+});

--- a/test/server/models/player.test.js
+++ b/test/server/models/player.test.js
@@ -279,3 +279,12 @@ test('player is booted from the old game if they join a new one', t => {
 
   t.true(player.leaveGame.called);
 });
+
+test('emitDelete emits a deleteItem event to the player', t => {
+  const {player} = setup();
+
+  const payload = {type: 'static', index: 1};
+  player.emitDelete(payload);
+
+  t.true(player.socket.emit.calledWith('deleteItem', payload));
+});

--- a/test/server/models/stats.test.js
+++ b/test/server/models/stats.test.js
@@ -7,6 +7,7 @@ import setup from '../stubs/create-socket';
 const genPlayer = () => {
   const {player} = setup();
   player.emitUpdate = stub();
+  player.emitDelete = stub();
 
   return player;
 };
@@ -134,6 +135,17 @@ test('can delete skill by index', t => {
   stats.deleteSkill(2);
 
   t.deepEqual(stats.skills, ['a', '', '']);
+});
+
+test('emits a delete event to the player on skill deletion', t => {
+  const player = genPlayer();
+  const stats = genStats(player);
+
+  stats.setSkill(1, 'a');
+
+  stats.deleteSkill(1);
+
+  t.true(player.emitDelete.calledWith({type: 'skill', index: 0}));
 });
 
 test('new skills are emitted', t => {


### PR DESCRIPTION
https://jira.kolya.cloud/browse/EIJ-35

Fixes a bug where skills would be improperly deleted, if the player was in progress of typing out a skill when the GM deleted one