### PR TITLE
[EIJ-46] Remove hard emits on server side

### DIFF
--- a/server/constants/index.js
+++ b/server/constants/index.js
@@ -1,0 +1,7 @@
+// @flow
+
+export const rooms = {
+  GM: 'gm',
+  PRIVATE: 'private',
+  GAME: 'game'
+};

--- a/server/constants/types.js
+++ b/server/constants/types.js
@@ -1,0 +1,9 @@
+// @flow
+
+export type RoomsType = {|
+  game: ?string,
+  private: ?string,
+  gm: ?string
+|};
+
+export type Rooms = 'game' | 'private' | 'gm';

--- a/server/models/game.js
+++ b/server/models/game.js
@@ -105,7 +105,7 @@ export default class Game {
   }
 
   gmEmitPlayers() {
-    this.owner.emitToMe({
+    this.emitToGm({
       event: 'setPlayers',
       payload: this.players.map(p => p && p.serialize && p.serialize()).filter(p => p !== null)
     });

--- a/server/models/game.js
+++ b/server/models/game.js
@@ -6,6 +6,7 @@ import {logInfo} from '../lib/logger';
 import Slug from '../lib/slug';
 import * as GameModes from '../lib/game-mode';
 import {gameRepository, playerRepository} from '../repositories';
+import {rooms} from '../constants';
 import Player from './player';
 import Auction from './auction';
 
@@ -82,8 +83,9 @@ export default class Game {
     }
 
     const {prefix} = this.__STATICS__;
-    player.socket.join(`${prefix}/all`);
-    player.socket.join(`${prefix}/player/${player.id}`);
+    player.assignRoom(rooms.GAME, `${prefix}/all`);
+    player.assignRoom(rooms.PRIVATE, `${prefix}/player/${player.id}`);
+
     player.socket.emit('gameJoinSuccess', this.id);
 
     player.emitUpdate(false);
@@ -96,8 +98,9 @@ export default class Game {
     const {prefix} = this.__STATICS__;
     this.owner.setGame(this);
 
-    this.owner.socket.join(`${prefix}/gm`);
-    this.owner.socket.join(`${prefix}/all`);
+    this.owner.assignRoom(rooms.GM, `${prefix}/gm`);
+    this.owner.assignRoom(rooms.GAME, `${prefix}/all`);
+
     this.emitGameMode('gm');
     this.owner.socket.emit('startGame', this.id);
   }

--- a/server/models/game.js
+++ b/server/models/game.js
@@ -72,7 +72,6 @@ export default class Game {
 
     const {prefix} = this.__STATICS__;
     player.assignRoom(rooms.GAME, `${prefix}/all`);
-    player.assignRoom(rooms.PRIVATE, `${prefix}/player/${player.id}`);
 
     emit({
       channel: player.rooms.private,

--- a/server/models/player.js
+++ b/server/models/player.js
@@ -14,8 +14,7 @@ import Stats from './stats';
 const chance = new Chance();
 
 type Socket = {
-  [string]: any,
-  rooms?: RoomsType
+  [string]: any
 };
 
 type IdType = string | null;
@@ -26,7 +25,8 @@ type StaticsType = {
   active: boolean,
   name: string,
   disconnectTimer: ?TimeoutID,
-  lastSerialized: {[string]: any}
+  lastSerialized: {[string]: any},
+  rooms: RoomsType
 };
 
 export default class Player {
@@ -43,7 +43,6 @@ export default class Player {
   constructor(socket: Socket, id: IdType = null) {
     id = id || uuid();
     socket.playerId = socket.playerId || id;
-    socket.rooms = socket.rooms || {};
 
     const name = chance.name({middle: true, prefix: true});
 
@@ -53,7 +52,8 @@ export default class Player {
       active: true,
       disconnectTimer: null,
       name,
-      lastSerialized: {}
+      lastSerialized: {},
+      rooms: {}
     };
 
     this.resetStats();
@@ -101,7 +101,11 @@ export default class Player {
 
   assignRoom(type: Room, name: string) {
     this.socket.join(name);
-    this.socket.rooms[type] = name;
+    this.__STATICS__.rooms[type] = name;
+  }
+
+  get rooms(): RoomsType {
+    return this.__STATICS__.rooms;
   }
 
   resetStats() {
@@ -221,7 +225,7 @@ export default class Player {
   }
 
   emitToMe({event, payload}: {event: string, payload?: any}) {
-    const channel = this.socket.rooms.private;
+    const channel = this.rooms.private;
 
     emit({channel, event, payload});
   }

--- a/server/models/player.js
+++ b/server/models/player.js
@@ -193,8 +193,7 @@ export default class Player {
     }
 
     if (this.game && emitToGm) {
-      this.game.emit({
-        channel: 'gm',
+      this.game.emitToGm({
         event,
         payload
       });
@@ -213,8 +212,7 @@ export default class Player {
     });
 
     if (this.game) {
-      this.game.emit({
-        channel: 'gm',
+      this.game.emitToGm({
         event: 'updatePlayer',
         payload: {
           id: this.id,

--- a/server/models/player.js
+++ b/server/models/player.js
@@ -110,13 +110,19 @@ export default class Player {
   }
 
   clearRooms() {
-    const roomNames = Object.values(this.rooms);
+    const types = Object.values(rooms);
 
-    for (const room of roomNames) {
-      this.__STATICS__.socket.leave(room);
+    const privateRoom = this.rooms[rooms.PRIVATE];
+
+    for (const type of types) {
+      if (type === rooms.PRIVATE) {
+        continue;
+      }
+
+      this.__STATICS__.socket.leave(this.rooms[type]);
     }
 
-    this.__STATICS__.rooms = {};
+    this.__STATICS__.rooms = {[rooms.PRIVATE]: privateRoom};
   }
 
   get rooms(): RoomsType {

--- a/server/models/player.js
+++ b/server/models/player.js
@@ -6,6 +6,7 @@ import {diff, updatedDiff} from 'deep-object-diff';
 
 import {logInfo} from '../lib/logger';
 import type {RoomsType, Room} from '../constants/types';
+import {rooms} from '../constants';
 import {gameRepository, playerRepository} from '../repositories';
 import {emit} from '../socket/emitter';
 import Game from './game';
@@ -55,6 +56,8 @@ export default class Player {
       lastSerialized: {},
       rooms: {}
     };
+
+    this.assignRoom(rooms.PRIVATE, `player/${this.id}`);
 
     this.resetStats();
 
@@ -201,7 +204,7 @@ export default class Player {
 
     const event = 'updatePlayer';
     if (emitToPlayer) {
-      this.emitToMe(event, payload);
+      this.emitToMe({event, payload});
     }
 
     if (this.game && emitToGm) {

--- a/server/models/player.js
+++ b/server/models/player.js
@@ -102,7 +102,7 @@ export default class Player {
   }
 
   assignRoom(type: Room, name: string) {
-    this.socket.join(name);
+    this.__STATICS__.socket.join(name);
     this.__STATICS__.rooms[type] = name;
   }
 
@@ -110,7 +110,7 @@ export default class Player {
     const roomNames = Object.values(this.rooms);
 
     for (const room of roomNames) {
-      this.socket.leave(room);
+      this.__STATICS__.socket.leave(room);
     }
 
     this.__STATICS__.rooms = {};
@@ -246,10 +246,6 @@ export default class Player {
 
   get active(): boolean {
     return this.__STATICS__.active;
-  }
-
-  get socket(): Socket {
-    return this.__STATICS__.socket;
   }
 
   get game(): Game {

--- a/server/models/player.js
+++ b/server/models/player.js
@@ -83,6 +83,8 @@ export default class Player {
       this.game.removePlayer(this, silent);
     }
 
+    this.clearRooms();
+
     this.__game = '';
   }
 
@@ -102,6 +104,16 @@ export default class Player {
   assignRoom(type: Room, name: string) {
     this.socket.join(name);
     this.__STATICS__.rooms[type] = name;
+  }
+
+  clearRooms() {
+    const roomNames = Object.values(this.rooms);
+
+    for (const room of roomNames) {
+      this.socket.leave(room);
+    }
+
+    this.__STATICS__.rooms = {};
   }
 
   get rooms(): RoomsType {

--- a/server/models/player.js
+++ b/server/models/player.js
@@ -5,13 +5,17 @@ import Chance from 'chance';
 import {diff, updatedDiff} from 'deep-object-diff';
 
 import {logInfo} from '../lib/logger';
+import type {RoomsType, Room} from '../constants/types';
 import {gameRepository, playerRepository} from '../repositories';
 import Game from './game';
 import Stats from './stats';
 
 const chance = new Chance();
 
-type Socket = {[string]: any};
+type Socket = {
+  [string]: any,
+  rooms?: RoomsType
+};
 
 type IdType = string | null;
 
@@ -38,6 +42,7 @@ export default class Player {
   constructor(socket: Socket, id: IdType = null) {
     id = id || uuid();
     socket.playerId = socket.playerId || id;
+    socket.rooms = socket.rooms || {};
 
     const name = chance.name({middle: true, prefix: true});
 
@@ -91,6 +96,11 @@ export default class Player {
     }
 
     this.__game = id;
+  }
+
+  assignRoom(type: Room, name: string) {
+    this.socket.join(name);
+    this.socket.rooms[type] = name;
   }
 
   resetStats() {

--- a/server/socket/actions/join-gm.js
+++ b/server/socket/actions/join-gm.js
@@ -26,7 +26,10 @@ const joinGm = (socket: SocketType, gameId: string) => {
     logError(`Game ${gameId} not found`);
   }
 
-  socket.emit('gameError', 'error.game.doesntExist');
+  player.emitToMe({
+    event: 'gameError',
+    payload: 'error.game.doesntExist'
+  });
 };
 
 export default joinGm;

--- a/server/socket/actions/start-playing.js
+++ b/server/socket/actions/start-playing.js
@@ -7,8 +7,7 @@ const startPlaying = (socket: SocketType) => {
   const {game} = socket;
 
   game.mode = GameModes.PLAYING;
-  game.emit({
-    channel: 'all',
+  game.emitToAll({
     event: 'startPlaying'
   });
 };

--- a/server/socket/emitter.js
+++ b/server/socket/emitter.js
@@ -1,15 +1,23 @@
 // @flow
 
-import socket from '.';
-
 type EmitArgs = {|
   event: 'string',
   payload?: any,
   channel?: string
 |};
 
+let socket;
+if (process.env.NODE_ENV === 'test') {
+  socket = require('.').default;
+} else {
+  setImmediate(() => {
+    socket = require('.').default;
+  });
+}
+
 export const emit = ({event, payload, channel}: EmitArgs) => {
-  const {emit: emitFn} = channel ? socket.to(channel) : socket;
+  const {emit: fn} = channel ? socket.to(channel) : socket;
+  const emitFn = fn.bind(socket);
 
   emitFn(event, payload);
 };

--- a/server/socket/emitter.js
+++ b/server/socket/emitter.js
@@ -16,8 +16,9 @@ if (process.env.NODE_ENV === 'test') {
 }
 
 export const emit = ({event, payload, channel}: EmitArgs) => {
-  const {emit: fn} = channel ? socket.to(channel) : socket;
-  const emitFn = fn.bind(socket);
+  const context = channel ? socket.to(channel) : socket;
+  const fn = context.emit;
+  const emitFn = fn.bind(context);
 
   emitFn(event, payload);
 };

--- a/server/socket/emitter.js
+++ b/server/socket/emitter.js
@@ -2,8 +2,8 @@
 
 type EmitArgs = {|
   event: 'string',
+  channel: string,
   payload?: any,
-  channel?: string
 |};
 
 let socket;
@@ -16,9 +16,5 @@ if (process.env.NODE_ENV === 'test') {
 }
 
 export const emit = ({event, payload, channel}: EmitArgs) => {
-  const context = channel ? socket.to(channel) : socket;
-  const fn = context.emit;
-  const emitFn = fn.bind(context);
-
-  emitFn(event, payload);
+  return socket.to(channel).emit(event, payload);
 };

--- a/server/socket/emitter.js
+++ b/server/socket/emitter.js
@@ -2,7 +2,7 @@
 
 type EmitArgs = {|
   event: 'string',
-  channel: string,
+  channel?: string,
   payload?: any,
 |};
 
@@ -16,5 +16,9 @@ if (process.env.NODE_ENV === 'test') {
 }
 
 export const emit = ({event, payload, channel}: EmitArgs) => {
-  return socket.to(channel).emit(event, payload);
+  const context = channel ? socket.to(channel) : socket;
+  const fn = context.emit;
+  const emitFn = fn.bind(context);
+
+  return emitFn(event, payload);
 };

--- a/server/socket/emitter.js
+++ b/server/socket/emitter.js
@@ -1,0 +1,15 @@
+// @flow
+
+import socket from '.';
+
+type EmitArgs = {|
+  event: 'string',
+  payload?: any,
+  channel?: string
+|};
+
+export const emit = ({event, payload, channel}: EmitArgs) => {
+  const {emit: emitFn} = channel ? socket.to(channel) : socket;
+
+  emitFn(event, payload);
+};

--- a/test/server/mocks/socket.js
+++ b/test/server/mocks/socket.js
@@ -21,6 +21,8 @@ export class MockSocket {
 
   join = spy();
 
+  leave = spy();
+
   to = stub().returns(socketToMocks);
 
   emit = spy();

--- a/test/server/models/game.test.js
+++ b/test/server/models/game.test.js
@@ -254,18 +254,6 @@ test('joins a user to the public room upon joining the game', t => {
   t.is(player.rooms[roomName], room);
 });
 
-test('joins a user to the private room upon joining', t => {
-  const game = genGame();
-  const player = new Player(new MockSocket(), 'id');
-
-  const roomName = 'private';
-  const room = `game/${game.id}/player/${player.id}`;
-
-  game.addPlayer(player);
-
-  t.is(player.rooms[roomName], room);
-});
-
 test('subscribes owner to GM and "all" rooms', t => {
   const {game, player: owner} = setup(true, true);
 

--- a/test/server/models/game.test.js
+++ b/test/server/models/game.test.js
@@ -166,7 +166,7 @@ test('emits mode to players', t => {
   game.mode = GameMode.VOTING;
 
   const payload = {
-    channel: 'all',
+    channel: game.__STATICS__.rooms[rooms.GAME],
     event: 'setGameMode',
     payload: 'VOTING'
   };
@@ -334,5 +334,28 @@ test('#emitToAll emits to the GAME room', t => {
     channel: owner.rooms.game,
     event,
     payload
+  }));
+});
+
+test('#emitGameMode emits to the GAME room by default', t => {
+  const {game, emit} = setup();
+
+  game.emitGameMode();
+
+  t.true(emit.calledWith({
+    channel: game.__STATICS__.rooms[rooms.GAME],
+    event: 'setGameMode',
+    payload: 'SETUP'
+  }));
+});
+
+test('#emitGameMode emits to the GM room if specificed', t => {
+  const {game} = setup();
+
+  game.emitGameMode(rooms.GM);
+
+  t.true(game.emitToGm.calledWith({
+    event: 'setGameMode',
+    payload: 'SETUP'
   }));
 });

--- a/test/server/models/game.test.js
+++ b/test/server/models/game.test.js
@@ -4,7 +4,7 @@ import {stub} from 'sinon';
 
 import Player from '../../../server/models/player';
 import {repositories} from '../mocks';
-import {MockSocket, socketToMocks} from '../mocks/socket';
+import {MockSocket} from '../mocks/socket';
 import {rooms} from '../../../server/constants';
 import * as GameMode from '../../../server/lib/game-mode';
 import setup from '../stubs/create-socket';
@@ -13,12 +13,10 @@ const mockBid = stub();
 class Auction {
   bid = mockBid;
 }
-const globalSocket = new MockSocket();
 
 const Game = proxyquire('../../../server/models/game', {
   '../repositories': repositories,
-  './auction': {default: Auction},
-  '../socket': {default: globalSocket}
+  './auction': {default: Auction}
 }).default;
 const {gameRepository, playerRepository} = repositories;
 
@@ -46,6 +44,16 @@ test('has an owner', t => {
   t.is(game.owner.id, owner.id);
 });
 
+test('emits a `startGame` event to the GM upon starting the game', t => {
+  const {game} = setup();
+
+  const event = 'startGame';
+  const payload = game.id;
+
+  game.gmInitGame();
+  t.true(game.emitToGm.calledWith({event, payload}));
+});
+
 test('can hold players', t => {
   const {game} = setup();
 
@@ -63,6 +71,19 @@ test('can add players', t => {
 
   t.is(game.players[0].id, players[0].id);
   t.is(game.players[1].id, players[1].id);
+});
+
+test('emits a `gameJoinSuccess` event to the players private room upon joining', t => {
+  const player = genPlayer();
+  const {game, emit} = setup(true, false, false);
+
+  game.addPlayer(player);
+
+  t.true(emit.calledWith({
+    channel: player.rooms.private,
+    event: 'gameJoinSuccess',
+    payload: game.id
+  }));
 });
 
 test('cannot add duplicate players', t => {
@@ -86,23 +107,29 @@ test('can remove players', t => {
 });
 
 test('emits a gameKick event to the player when kicked', t => {
-  const {game, player} = setup();
+  const {game, player, emit} = setup();
 
   game.addPlayer(player);
 
   game.removePlayer(player);
 
-  t.true(player.socket.emit.calledWith('gameKick'));
+  t.true(emit.calledWith({
+    channel: player.rooms.private,
+    event: 'gameKick'
+  }));
 });
 
 test('does not emit a gameKick event to the player if silent is true', t => {
-  const {game, player} = setup();
+  const {game, player, emit} = setup();
 
   game.addPlayer(player);
 
   game.removePlayer(player, true);
 
-  t.false(player.socket.emit.calledWith('gameKick'));
+  t.false(emit.calledWith({
+    channel: player.rooms.private,
+    event: 'gameKick'
+  }));
 });
 
 test('gets stored in the game repository during the constructor', t => {
@@ -134,8 +161,7 @@ test('can change modes', t => {
 });
 
 test('emits mode to players', t => {
-  const {game} = setup();
-  game.emit = stub();
+  const {game, emit} = setup();
 
   game.mode = GameMode.VOTING;
 
@@ -145,7 +171,7 @@ test('emits mode to players', t => {
     payload: 'VOTING'
   };
 
-  t.true(game.emit.calledWith(payload));
+  t.true(emit.calledWith(payload));
 });
 
 test('cannot set invalid modes', t => {
@@ -240,22 +266,6 @@ test('joins a user to the private room upon joining', t => {
   t.is(player.rooms[roomName], room);
 });
 
-test('can emit to all players in the game', t => {
-  const game = genGame();
-
-  const event = 'event';
-  const payload = 'payload';
-
-  game.emit({
-    channel: 'all',
-    event,
-    payload
-  });
-
-  t.true(globalSocket.to.calledWith(`game/${game.id}/all`));
-  t.true(socketToMocks.emit.calledWith(event, payload));
-});
-
 test('subscribes owner to GM and "all" rooms', t => {
   const {game, player: owner} = setup(true, true);
 
@@ -291,37 +301,50 @@ test('emits players to GM upon adding player to game', t => {
   const {game} = setup(true, true);
   const {player} = setup(false);
 
-  const payload = [player.serialize()];
-
-  const expected = {
-    channel: 'gm',
-    event: 'setPlayers',
-    payload
-  };
-
-  game.emit = stub();
   game.addPlayer(player);
 
-  t.true(player.emitUpdate.calledWith(false));
-  t.true(game.emit.calledWith(expected));
+  t.true(game.gmEmitPlayers.called);
 });
 
 test('#gmEmitPlayers emits players to GM', t => {
-  const {game} = setup(true, true);
+  const {game, player: owner} = setup(true, true);
   const {player} = setup(false);
 
   const payload = [player.serialize()];
 
   const expected = {
-    channel: 'gm',
     event: 'setPlayers',
     payload
   };
 
-  game.emit = stub();
   game.addPlayer(player);
-  game.emit.reset();
 
-  game.gmEmitPlayers();
-  t.true(game.emit.calledWith(expected));
+  t.true(owner.emitToMe.calledWith(expected));
+});
+
+test('#emitToGm emits to the GMs private channel', t => {
+  const {game, player: owner} = setup(true, true);
+
+  const event = 'blah';
+  const payload = 'payload';
+  game.emitToGm({event, payload});
+
+  t.true(owner.emitToMe.calledWith({
+    event,
+    payload
+  }));
+});
+
+test('#emitToAll emits to the GAME room', t => {
+  const {game, emit, player: owner} = setup(true, true);
+
+  const event = 'blah';
+  const payload = 'payload';
+  game.emitToAll({event, payload});
+
+  t.true(emit.calledWith({
+    channel: owner.rooms.game,
+    event,
+    payload
+  }));
 });

--- a/test/server/models/game.test.js
+++ b/test/server/models/game.test.js
@@ -222,19 +222,21 @@ test('joins a user to the public room upon joining the game', t => {
   const {game, player} = setup();
 
   const room = `game/${game.id}/all`;
+  const roomName = 'game';
 
-  t.true(player.socket.join.calledWith(room));
+  t.is(player.socket.rooms[roomName], room);
 });
 
 test('joins a user to the private room upon joining', t => {
   const game = genGame();
   const player = new Player(new MockSocket(), 'id');
 
+  const roomName = 'private';
   const room = `game/${game.id}/player/${player.id}`;
 
   game.addPlayer(player);
 
-  t.true(player.socket.join.calledWith(room));
+  t.is(player.socket.rooms[roomName], room);
 });
 
 test('can emit to all players in the game', t => {
@@ -256,8 +258,14 @@ test('can emit to all players in the game', t => {
 test('subscribes owner to GM and "all" rooms', t => {
   const {game, player: owner} = setup(true, true);
 
-  t.true(owner.socket.join.calledWith(`game/${game.id}/gm`));
-  t.true(owner.socket.join.calledWith(`game/${game.id}/all`));
+  const roomName = 'gm';
+  const room = `game/${game.id}/gm`;
+
+  const allRoomName = 'game';
+  const allRoom = `game/${game.id}/all`;
+
+  t.is(owner.socket.rooms[roomName], room);
+  t.is(owner.socket.rooms[allRoomName], allRoom);
 });
 
 test('subtracts willpower from auction winner and enters playing mode', t => {

--- a/test/server/models/game.test.js
+++ b/test/server/models/game.test.js
@@ -5,6 +5,7 @@ import {stub} from 'sinon';
 import Player from '../../../server/models/player';
 import {repositories} from '../mocks';
 import {MockSocket, socketToMocks} from '../mocks/socket';
+import {rooms} from '../../../server/constants';
 import * as GameMode from '../../../server/lib/game-mode';
 import setup from '../stubs/create-socket';
 
@@ -222,9 +223,9 @@ test('joins a user to the public room upon joining the game', t => {
   const {game, player} = setup();
 
   const room = `game/${game.id}/all`;
-  const roomName = 'game';
+  const roomName = rooms.GAME;
 
-  t.is(player.socket.rooms[roomName], room);
+  t.is(player.rooms[roomName], room);
 });
 
 test('joins a user to the private room upon joining', t => {
@@ -236,7 +237,7 @@ test('joins a user to the private room upon joining', t => {
 
   game.addPlayer(player);
 
-  t.is(player.socket.rooms[roomName], room);
+  t.is(player.rooms[roomName], room);
 });
 
 test('can emit to all players in the game', t => {
@@ -264,8 +265,8 @@ test('subscribes owner to GM and "all" rooms', t => {
   const allRoomName = 'game';
   const allRoom = `game/${game.id}/all`;
 
-  t.is(owner.socket.rooms[roomName], room);
-  t.is(owner.socket.rooms[allRoomName], allRoom);
+  t.is(owner.rooms[roomName], room);
+  t.is(owner.rooms[allRoomName], allRoom);
 });
 
 test('subtracts willpower from auction winner and enters playing mode', t => {

--- a/test/server/models/player.test.js
+++ b/test/server/models/player.test.js
@@ -309,6 +309,23 @@ test('emitSkill emits a setSkill event to the player', t => {
   t.true(emit.calledWith({channel, event, payload}));
 });
 
+test('emitSkill calls game.emitToGm', t => {
+  const {game, player} = setup();
+
+  const skill = 'skill';
+  player.stats.__STATICS__.skill1 = skill;
+
+  player.emitSkill(0);
+
+  t.true(game.emitToGm.calledWith({
+    event: 'updatePlayer',
+    payload: {
+      id: player.id,
+      skill1: skill
+    }
+  }));
+});
+
 test('emitUpdate does not emit anything if there has been no change since the last update', t => {
   const {player} = setup();
 

--- a/test/server/models/player.test.js
+++ b/test/server/models/player.test.js
@@ -165,6 +165,7 @@ test('is subscribed to the public game room upon joining the game', t => {
   player.joinGame(game.id);
 
   t.true(player.socket.join.calledWith(room));
+  t.is(player.socket.rooms.game, room);
 });
 
 test('is subscribed to the private channel upon joining the game', t => {
@@ -177,6 +178,7 @@ test('is subscribed to the private channel upon joining the game', t => {
   game.addPlayer(player);
 
   t.true(player.socket.join.calledWith(room));
+  t.is(player.socket.rooms.private, room);
 });
 
 test('has a disconnect timeout set if they leave', t => {
@@ -322,4 +324,16 @@ test('emitUpdate emits only the changed values', t => {
   player.stats.willpower = willpower;
 
   t.true(player.socket.emit.calledWithExactly('updatePlayer', {id, willpower}));
+});
+
+test('#assignRoom sets the room', t => {
+  const {player} = setup();
+
+  const roomType = 'gm';
+  const roomName = 'room/name';
+
+  player.assignRoom(roomType, roomName);
+
+  t.true(player.socket.join.calledWith(roomName));
+  t.is(player.socket.rooms[roomType], roomName);
 });

--- a/test/server/models/player.test.js
+++ b/test/server/models/player.test.js
@@ -373,3 +373,26 @@ test('#emitToMe emits to my channel', t => {
     payload
   }));
 });
+
+test('#leaveGame calls #clearRooms', t => {
+  const {player} = setup();
+
+  player.leaveGame();
+
+  t.true(player.clearRooms.called);
+});
+
+test('#clearRooms removes the players from all rooms', t => {
+  const {player} = setup();
+
+  const rooms = {...player.rooms};
+  const roomNames = Object.values(rooms);
+
+  player.clearRooms();
+
+  for (const room of roomNames) {
+    t.true(player.socket.leave.calledWith(room));
+  }
+
+  t.deepEqual(player.rooms, {});
+});

--- a/test/server/models/player.test.js
+++ b/test/server/models/player.test.js
@@ -6,6 +6,7 @@ import uuid from 'uuid/v4';
 import {repositories} from '../mocks';
 import {MockSocket} from '../mocks/socket';
 import setup from '../stubs/create-socket';
+import {rooms} from '../../../server/constants';
 import Stats from '../../../server/models/stats';
 import Game from '../../../server/models/game';
 
@@ -167,7 +168,7 @@ test('is subscribed to the public game room upon joining the game', t => {
   player.joinGame(game.id);
 
   t.true(player.socket.join.calledWith(room));
-  t.is(player.socket.rooms.game, room);
+  t.is(player.rooms.game, room);
 });
 
 test('is subscribed to the private channel upon joining the game', t => {
@@ -179,8 +180,7 @@ test('is subscribed to the private channel upon joining the game', t => {
 
   game.addPlayer(player);
 
-  t.true(player.socket.join.calledWith(room));
-  t.is(player.socket.rooms.private, room);
+  t.true(player.assignRoom.calledWith(rooms.PRIVATE, room));
 });
 
 test('has a disconnect timeout set if they leave', t => {
@@ -304,7 +304,7 @@ test('emitSkill emits a setSkill event to the player', t => {
   player.emitSkill(0);
   const event = 'setSkill';
   const payload = {index: 0, skill};
-  const channel = player.socket.rooms.private;
+  const channel = player.rooms.private;
 
   t.true(emit.calledWith({channel, event, payload}));
 });
@@ -339,7 +339,7 @@ test('#assignRoom sets the room', t => {
   player.assignRoom(roomType, roomName);
 
   t.true(player.socket.join.calledWith(roomName));
-  t.is(player.socket.rooms[roomType], roomName);
+  t.is(player.rooms[roomType], roomName);
 });
 
 test('#emitToMe emits to my channel', t => {
@@ -351,7 +351,7 @@ test('#emitToMe emits to my channel', t => {
   player.emitToMe({event, payload});
 
   t.true(emit.calledWith({
-    channel: player.socket.rooms.private,
+    channel: player.rooms.private,
     event,
     payload
   }));

--- a/test/server/models/player.test.js
+++ b/test/server/models/player.test.js
@@ -98,6 +98,13 @@ test('has a socket', t => {
   t.is(player.__STATICS__.socket, socket);
 });
 
+test('is subscribed to the private room upon instantiation', t => {
+  const {player} = setup();
+  const room = `player/${player.id}`;
+
+  t.is(player.rooms[rooms.PRIVATE], room);
+});
+
 test('gets stored in the repository', t => {
   const player = genPlayer();
 
@@ -169,18 +176,6 @@ test('is subscribed to the public game room upon joining the game', t => {
 
   t.true(player.__STATICS__.socket.join.calledWith(room));
   t.is(player.rooms.game, room);
-});
-
-test('is subscribed to the private channel upon joining the game', t => {
-  const {game, player} = setup();
-
-  gameRepository.find = stub().returns(game);
-
-  const room = `game/${game.id}/player/${player.id}`;
-
-  game.addPlayer(player);
-
-  t.true(player.assignRoom.calledWith(rooms.PRIVATE, room));
 });
 
 test('has a disconnect timeout set if they leave', t => {
@@ -344,7 +339,10 @@ test('emitUpdate emits only the changed values', t => {
 
   player.stats.willpower = willpower;
 
-  t.true(player.emitToMe.calledWithExactly('updatePlayer', {id, willpower}));
+  t.true(player.emitToMe.calledWithExactly({
+    event: 'updatePlayer',
+    payload: {id, willpower}
+  }));
 });
 
 test('#assignRoom sets the room', t => {

--- a/test/server/models/player.test.js
+++ b/test/server/models/player.test.js
@@ -30,7 +30,7 @@ test('it has an ID', t => {
 test('it appends the ID to the socket', t => {
   const player = new Player(new MockSocket());
 
-  t.is(player.socket.playerId, player.id);
+  t.is(player.__STATICS__.socket.playerId, player.id);
 });
 
 test('it has a default name', t => {
@@ -95,7 +95,7 @@ test('can be instantiated with a given ID', t => {
 test('has a socket', t => {
   const player = genPlayer();
 
-  t.is(player.socket, socket);
+  t.is(player.__STATICS__.socket, socket);
 });
 
 test('gets stored in the repository', t => {
@@ -167,7 +167,7 @@ test('is subscribed to the public game room upon joining the game', t => {
 
   player.joinGame(game.id);
 
-  t.true(player.socket.join.calledWith(room));
+  t.true(player.__STATICS__.socket.join.calledWith(room));
   t.is(player.rooms.game, room);
 });
 
@@ -355,7 +355,7 @@ test('#assignRoom sets the room', t => {
 
   player.assignRoom(roomType, roomName);
 
-  t.true(player.socket.join.calledWith(roomName));
+  t.true(player.__STATICS__.socket.join.calledWith(roomName));
   t.is(player.rooms[roomType], roomName);
 });
 
@@ -391,7 +391,7 @@ test('#clearRooms removes the players from all rooms', t => {
   player.clearRooms();
 
   for (const room of roomNames) {
-    t.true(player.socket.leave.calledWith(room));
+    t.true(player.__STATICS__.socket.leave.calledWith(room));
   }
 
   t.deepEqual(player.rooms, {});

--- a/test/server/models/player.test.js
+++ b/test/server/models/player.test.js
@@ -380,17 +380,21 @@ test('#leaveGame calls #clearRooms', t => {
   t.true(player.clearRooms.called);
 });
 
-test('#clearRooms removes the players from all rooms', t => {
+test('#clearRooms removes the players from all game rooms', t => {
   const {player} = setup();
 
-  const rooms = {...player.rooms};
-  const roomNames = Object.values(rooms);
+  const roomObj = {...player.rooms};
+  const privateRoom = roomObj[rooms.PRIVATE];
+  delete roomObj[rooms.PRIVATE];
+  const roomValues = Object.values(roomObj);
+
+  const newRooms = {[rooms.PRIVATE]: privateRoom};
 
   player.clearRooms();
 
-  for (const room of roomNames) {
+  for (const room of roomValues) {
     t.true(player.__STATICS__.socket.leave.calledWith(room));
   }
 
-  t.deepEqual(player.rooms, {});
+  t.deepEqual(player.rooms, newRooms);
 });

--- a/test/server/socket/actions/create-game.test.js
+++ b/test/server/socket/actions/create-game.test.js
@@ -10,5 +10,8 @@ test('creates a game', t => {
   createGame(socket);
 
   t.true(player.socket.join.calledWith(match.string));
-  t.true(player.socket.emit.calledWith('startGame', match.string));
+  t.true(player.emitToMe.calledWith({
+    event: 'startGame',
+    payload: match.string
+  }));
 });

--- a/test/server/socket/actions/create-game.test.js
+++ b/test/server/socket/actions/create-game.test.js
@@ -9,7 +9,7 @@ test('creates a game', t => {
 
   createGame(socket);
 
-  t.true(player.socket.join.calledWith(match.string));
+  t.true(player.assignRoom.calledWith(match.string));
   t.true(player.emitToMe.calledWith({
     event: 'startGame',
     payload: match.string

--- a/test/server/socket/actions/join-game.test.js
+++ b/test/server/socket/actions/join-game.test.js
@@ -19,5 +19,5 @@ test('pings back an error if the game does not exist', t => {
   joinGame(socket, 'ABCDE');
 
   t.is(player.game, null);
-  t.true(player.socket.emit.calledWith('gameError', 'error.game.doesntExist'));
+  t.true(player.emitToMe.calledWith('gameError', 'error.game.doesntExist'));
 });

--- a/test/server/socket/actions/join-gm.test.js
+++ b/test/server/socket/actions/join-gm.test.js
@@ -27,7 +27,10 @@ test('pings back an error if the game exists, but the player is not the GM', t =
   joinGm(socket, game.id);
 
   t.is(player.game, null);
-  t.true(player.socket.emit.calledWith('gameError', 'error.game.doesntExist'));
+  t.true(player.emitToMe.calledWith({
+    event: 'gameError',
+    payload: 'error.game.doesntExist'
+  }));
 });
 
 test('pings back an error if the game does not exist', t => {
@@ -37,5 +40,8 @@ test('pings back an error if the game does not exist', t => {
   joinGm(socket, 'ABCDE');
 
   t.is(player.game, null);
-  t.true(player.socket.emit.calledWith('gameError', 'error.game.doesntExist'));
+  t.true(player.emitToMe.calledWith({
+    event: 'gameError',
+    payload: 'error.game.doesntExist'
+  }));
 });

--- a/test/server/socket/actions/start-playing.test.js
+++ b/test/server/socket/actions/start-playing.test.js
@@ -10,3 +10,10 @@ test('puts the game in PLAYING mode', t => {
 
   t.is(game.mode, GameModes.PLAYING);
 });
+
+test('emits startPlaying to all players & gm', t => {
+  const {socket, game} = setup(true, true);
+  startPlaying(socket);
+
+  t.true(game.emitToAll.calledWith({event: 'startPlaying'}));
+});

--- a/test/server/socket/emitter.test.js
+++ b/test/server/socket/emitter.test.js
@@ -1,0 +1,33 @@
+import test from 'ava';
+import proxyquire from 'proxyquire';
+import {MockSocket, socketToMocks} from '../mocks/socket';
+
+const socket = new MockSocket();
+const {emit} = proxyquire('../../../server/socket/emitter', {
+  '.': {default: socket}
+});
+
+const channel = 'someChannel';
+const event = 'someEvent';
+const payload = {
+  some: 'payload'
+};
+
+test('when no channel provided, calls emit directly', t => {
+  emit({event, payload});
+
+  t.true(socket.emit.calledWith(event, payload));
+});
+
+test('does not require a paylaod', t => {
+  emit({event});
+
+  t.true(socket.emit.calledWith(event, undefined));
+});
+
+test('when a channel is provided, calls socket.to then emit', t => {
+  emit({channel, event, payload});
+
+  t.true(socket.to.calledWith(channel));
+  t.true(socketToMocks.emit.calledWith(event, payload));
+});

--- a/test/server/socket/emitter.test.js
+++ b/test/server/socket/emitter.test.js
@@ -26,3 +26,9 @@ test('can emit with a payload', t => {
   t.true(socket.to.calledWith(channel));
   t.true(socketToMocks.emit.calledWith(event, payload));
 });
+
+test('if called without a channel, eits globally', t => {
+  emit({event, payload});
+
+  t.true(socket.emit.calledWith(event, payload));
+});

--- a/test/server/socket/emitter.test.js
+++ b/test/server/socket/emitter.test.js
@@ -13,19 +13,14 @@ const payload = {
   some: 'payload'
 };
 
-test('when no channel provided, calls emit directly', t => {
-  emit({event, payload});
-
-  t.true(socket.emit.calledWith(event, payload));
-});
-
 test('does not require a paylaod', t => {
-  emit({event});
+  emit({channel, event});
 
-  t.true(socket.emit.calledWith(event, undefined));
+  t.true(socket.to.calledWith(channel));
+  t.true(socketToMocks.emit.calledWith(event, undefined));
 });
 
-test('when a channel is provided, calls socket.to then emit', t => {
+test('can emit with a payload', t => {
   emit({channel, event, payload});
 
   t.true(socket.to.calledWith(channel));

--- a/test/server/stubs/create-socket.js
+++ b/test/server/stubs/create-socket.js
@@ -2,7 +2,6 @@ import proxyquire from 'proxyquire';
 import {stub} from 'sinon';
 
 import {MockSocket} from '../mocks/socket';
-import Game from '../../../server/models/game';
 
 const methods = [
   'deactivate',
@@ -22,8 +21,10 @@ const gameMethods = [
   'removePlayer',
   'addBid',
   'destroy',
-  'emit',
-  'gmEmitPlayers'
+  'gmEmitPlayers',
+  'emitToGm',
+  'gmInitGame',
+  'emitToAll'
 ];
 
 const stubAndCallThrough = (obj, func) => {
@@ -36,6 +37,9 @@ const stubAndCallThrough = (obj, func) => {
 const setup = (createGame = true, playerIsOwner = false, joinToGame = true) => {
   const emit = stub();
   const Player = proxyquire('../../../server/models/player', {
+    '../socket/emitter': {emit}
+  }).default;
+  const Game = proxyquire('../../../server/models/game', {
     '../socket/emitter': {emit}
   }).default;
   const owner = new Player(new MockSocket());

--- a/test/server/stubs/create-socket.js
+++ b/test/server/stubs/create-socket.js
@@ -12,7 +12,8 @@ const methods = [
   'disconnect',
   'reconnect',
   'destroy',
-  'emitUpdate'
+  'emitUpdate',
+  'assignRoom'
 ];
 
 const gameMethods = [

--- a/test/server/stubs/create-socket.js
+++ b/test/server/stubs/create-socket.js
@@ -13,7 +13,8 @@ const methods = [
   'destroy',
   'emitUpdate',
   'assignRoom',
-  'emitToMe'
+  'emitToMe',
+  'clearRooms'
 ];
 
 const gameMethods = [

--- a/test/server/stubs/create-socket.js
+++ b/test/server/stubs/create-socket.js
@@ -1,7 +1,7 @@
+import proxyquire from 'proxyquire';
 import {stub} from 'sinon';
 
 import {MockSocket} from '../mocks/socket';
-import Player from '../../../server/models/player';
 import Game from '../../../server/models/game';
 
 const methods = [
@@ -13,7 +13,8 @@ const methods = [
   'reconnect',
   'destroy',
   'emitUpdate',
-  'assignRoom'
+  'assignRoom',
+  'emitToMe'
 ];
 
 const gameMethods = [
@@ -33,6 +34,10 @@ const stubAndCallThrough = (obj, func) => {
 };
 
 const setup = (createGame = true, playerIsOwner = false, joinToGame = true) => {
+  const emit = stub();
+  const Player = proxyquire('../../../server/models/player', {
+    '../socket/emitter': {emit}
+  }).default;
   const owner = new Player(new MockSocket());
   const socket = new MockSocket();
   const player = new Player(socket);
@@ -61,7 +66,7 @@ const setup = (createGame = true, playerIsOwner = false, joinToGame = true) => {
     socket.game = game;
   }
 
-  return {player, socket, game};
+  return {player, socket, game, emit};
 };
 
 export default setup;


### PR DESCRIPTION
https://jira.kolya.cloud/browse/EIJ-46

We have a room system set up so..

- Remove all instances of "hard" `socket.emit` (including `this.socket.emit`, `this.game.socket.emit`, etc) and replace with helper functions.
  - Makes the emits more verbose in where they're going `emitToAll`, `emitToGm`, `emitToMe`, etc.
  - These were primarily in `models/player.js` and `models/game.js`
- Add helper file to facilitate emitting to rooms 
- _Note:_ Does not touch `socket.emit` in the client side javascript, since there is only one emit function there. The server has to handle multiple games / players, hence rooms.