### PR TITLE
[EIJ-38] Avoid unnecessary store updates

### DIFF
--- a/client/components/game/goal.js
+++ b/client/components/game/goal.js
@@ -6,7 +6,6 @@ import debounce from 'debounce';
 import socket from '../../socket';
 import {DEBOUNCE_AMOUNT} from '../../constants/sockets';
 
-import {store} from '../../store';
 import globalStyles from '../../sass/global.scss';
 import styles from './section.scss';
 
@@ -15,9 +14,17 @@ type Props = {|
   frozen: boolean
 |};
 
-export default class Goal extends React.Component<Props> {
+type State = {|
+  value: string
+|};
+
+export default class Goal extends React.Component<Props, State> {
   constructor(...args) {
     super(...args);
+
+    this.state = {
+      value: this.props.value || ''
+    };
 
     this.submitGoal = debounce(this.submitGoal, DEBOUNCE_AMOUNT);
   }
@@ -31,10 +38,7 @@ export default class Goal extends React.Component<Props> {
       }
     } = e;
 
-    store.dispatch({
-      type: 'SET_PLAYER_INFO',
-      payload: {goal}
-    });
+    this.setState({value: goal});
 
     this.submitGoal(goal);
   }
@@ -44,7 +48,8 @@ export default class Goal extends React.Component<Props> {
   }
 
   renderGoal = () => {
-    const {frozen, value} = this.props;
+    const {frozen} = this.props;
+    const {value} = this.state;
 
     if (frozen) {
       return <span data-type="goal">{value}</span>;

--- a/client/components/game/name.js
+++ b/client/components/game/name.js
@@ -16,19 +16,18 @@ class Name extends React.Component<Props> {
   constructor(...args) {
     super(...args);
 
-    this.debounced = (e: SyntheticInputEvent<HTMLInputElement>) => {
-      e.persist();
-      const {
-        target: {
-          value: name
-        }
-      } = e;
-
-      debounce(this.handleChange, DEBOUNCE_AMOUNT)(name);
-    };
+    this.handleChange = debounce(this.handleChange, DEBOUNCE_AMOUNT);
   }
 
-  handleChange = (name: string) => {
+  handleChange = (e: SyntheticInputEvent<HTMLInputElement>) => {
+    e.persist();
+
+    const {
+      target: {
+        value: name
+      }
+    } = e;
+
     socket.emit('updatePlayer', {name});
   }
 
@@ -42,7 +41,7 @@ class Name extends React.Component<Props> {
           className={styles.text}
           data-type="name"
           defaultValue={value}
-          onChange={this.debounced}
+          onChange={this.handleChange}
         />
       </div>
     );

--- a/client/components/game/name.js
+++ b/client/components/game/name.js
@@ -12,27 +12,41 @@ type Props = {|
   value: string
 |};
 
-class Name extends React.Component<Props> {
+type State = {|
+  value: string
+|};
+
+class Name extends React.Component<Props, State> {
   constructor(...args) {
     super(...args);
 
-    this.handleChange = debounce(this.handleChange, DEBOUNCE_AMOUNT);
+    this.state = {
+      value: this.props.value
+    };
+
+    this.submitName = debounce(this.submitName, DEBOUNCE_AMOUNT);
   }
 
-  handleChange = (e: SyntheticInputEvent<HTMLInputElement>) => {
+  handleInput = (e: SyntheticInputEvent<HTMLInputElement>) => {
     e.persist();
 
     const {
       target: {
-        value: name
+        value
       }
     } = e;
 
+    this.setState({value});
+
+    this.submitName(value);
+  };
+
+  submitName = (name: string) => {
     socket.emit('updatePlayer', {name});
   }
 
   render() {
-    const {value} = this.props;
+    const {value} = this.state;
 
     return (
       <div className={styles.name}>
@@ -40,8 +54,9 @@ class Name extends React.Component<Props> {
         <input
           className={styles.text}
           data-type="name"
-          defaultValue={value}
-          onChange={this.handleChange}
+          value={value}
+          onInput={this.handleInput}
+          onChange={this.handleInput}
         />
       </div>
     );

--- a/client/components/game/player-info.js
+++ b/client/components/game/player-info.js
@@ -17,7 +17,9 @@ import styles from './player-info.scss';
 type Props = {|
   name: string,
   willpower: number,
-  skills: Array<string>,
+  skill1: string,
+  skill2: string,
+  skill3: string,
   goal: string,
   points: number,
   frozen: boolean,
@@ -48,11 +50,15 @@ class PlayerInfo extends React.Component<Props> {
       name,
       willpower,
       goal,
-      skills: items,
+      skill1,
+      skill2,
+      skill3,
       points: score,
       frozen,
       winner
     } = this.props;
+
+    const skills = {skill1, skill2, skill3};
 
     return (
       <div className={styles.player}>
@@ -62,7 +68,7 @@ class PlayerInfo extends React.Component<Props> {
         {this.renderBidding()}
         <Score value={score}/>
         <Goal value={goal} frozen={frozen}/>
-        <SkillList items={items} frozen={frozen}/>
+        <SkillList frozen={frozen} {...skills}/>
       </div>
     );
   }
@@ -82,12 +88,13 @@ const mapStateToProps = ({player, game}: GameStateType) => {
   } = player;
 
   const {mode} = game;
-  const skills = [skill1, skill2, skill3];
 
   return {
     name,
     willpower,
-    skills,
+    skill1,
+    skill2,
+    skill3,
     goal,
     points,
     frozen,

--- a/client/components/game/skill-list.js
+++ b/client/components/game/skill-list.js
@@ -42,6 +42,17 @@ export default class SkillList extends React.Component<Props, State> {
     });
   }
 
+  static getDerivedStateFromProps(props: Props, state: State): ?State {
+    const {items: newItems} = props;
+    const {items} = state;
+
+    if (JSON.stringify(newItems) !== JSON.stringify(items)) {
+      return {items: newItems};
+    }
+
+    return null;
+  }
+
   handleInput = (e: SyntheticInputEvent<HTMLInputElement>, index: number) => {
     e.persist();
 

--- a/client/components/game/skill-list.js
+++ b/client/components/game/skill-list.js
@@ -6,7 +6,6 @@ import debounce from 'debounce';
 
 import {DEBOUNCE_AMOUNT} from '../../constants/sockets';
 
-import {store} from '../../store';
 import globalStyles from '../../sass/global.scss';
 import socket from '../../socket';
 
@@ -18,7 +17,8 @@ type Props = {|
 |};
 
 type State = {|
-  ids: Array<string>
+  ids: Array<string>,
+  items: Array<string>
 |};
 
 export default class SkillList extends React.Component<Props, State> {
@@ -32,7 +32,10 @@ export default class SkillList extends React.Component<Props, State> {
       ids[i] = uuid();
     }
 
-    this.state = {ids};
+    this.state = {
+      ids,
+      items: this.props.items || new Array(3).fill('')
+    };
 
     this.changeHandler = new Array(3).fill(0).map((_, i) => {
       return debounce(this.handleChange.bind(this, i), DEBOUNCE_AMOUNT);
@@ -48,12 +51,10 @@ export default class SkillList extends React.Component<Props, State> {
       }
     } = e;
 
-    store.dispatch({
-      type: 'SET_PLAYER_INFO',
-      payload: {
-        [`skill${index + 1}`]: value
-      }
-    });
+    const {items} = this.state;
+    items[index] = value;
+
+    this.setState({items});
 
     this.changeHandler[index](value);
   }
@@ -93,8 +94,7 @@ export default class SkillList extends React.Component<Props, State> {
   }
 
   render() {
-    const {ids} = this.state;
-    const {items} = this.props;
+    const {ids, items} = this.state;
 
     return (
       <div className={styles.section}>

--- a/client/components/game/skill-list.js
+++ b/client/components/game/skill-list.js
@@ -18,7 +18,9 @@ type Props = {|
 
 type State = {|
   ids: Array<string>,
-  items: Array<string>
+  skill1: string,
+  skill2: string,
+  skill3: string
 |};
 
 export default class SkillList extends React.Component<Props, State> {
@@ -32,9 +34,12 @@ export default class SkillList extends React.Component<Props, State> {
       ids[i] = uuid();
     }
 
+    const [skill1, skill2, skill3] = this.props.items || [];
     this.state = {
       ids,
-      items: this.props.items || new Array(3).fill('')
+      skill1: skill1 || '',
+      skill2: skill2 || '',
+      skill3: skill3 || ''
     };
 
     this.changeHandler = new Array(3).fill(0).map((_, i) => {
@@ -42,15 +47,35 @@ export default class SkillList extends React.Component<Props, State> {
     });
   }
 
-  static getDerivedStateFromProps(props: Props, state: State): ?State {
-    const {items: newItems} = props;
-    const {items} = state;
-
-    if (JSON.stringify(newItems) !== JSON.stringify(items)) {
-      return {items: newItems};
+  componentDidUpdate(prevProps: Props): void {
+    if (JSON.stringify(prevProps) === JSON.stringify(this.props)) {
+      // Props have not changed, ignore
+      return;
     }
 
-    return null;
+    const {
+      skill1: s1,
+      skill2: s2,
+      skill3: s3
+    } = this.state;
+    const items = [s1, s2, s3];
+
+    const {items: newItems} = this.props;
+
+    if (JSON.stringify(newItems) !== JSON.stringify(items)) {
+      // The incoming props changed, we must update the state (i.e., rejected)
+      const [skill1, skill2, skill3] = newItems;
+
+      /*
+         (6/6/19) Disabling the rule here, since the skill rejection is a fairly specific case
+         and we actually do need the state updated to properly reflect the data to the user, due
+         to the input value being changed by a socket event / redux action.
+
+         I intend to revisit this in a future bug, and address this properly.
+      */
+      // eslint-disable-next-line react/no-did-update-set-state
+      this.setState({skill1, skill2, skill3});
+    }
   }
 
   handleInput = (e: SyntheticInputEvent<HTMLInputElement>, index: number) => {
@@ -62,10 +87,11 @@ export default class SkillList extends React.Component<Props, State> {
       }
     } = e;
 
-    const {items} = this.state;
-    items[index] = value;
+    console.log('Skill', index + 1, value);
 
-    this.setState({items});
+    this.setState({
+      [`skill${index + 1}`]: value
+    });
 
     this.changeHandler[index](value);
   }
@@ -105,7 +131,14 @@ export default class SkillList extends React.Component<Props, State> {
   }
 
   render() {
-    const {ids, items} = this.state;
+    const {
+      ids,
+      skill1,
+      skill2,
+      skill3
+    } = this.state;
+
+    const items = [skill1, skill2, skill3];
 
     return (
       <div className={styles.section}>

--- a/client/reducers/game.js
+++ b/client/reducers/game.js
@@ -12,7 +12,6 @@ const setSpecificPlayer = (state: GameStateType, {payload}: ActionType) => {
   }
 
   players[index] = deepMerge(players[index], payload);
-  console.log(players[index].id, payload);
   return {
     ...state,
     players

--- a/test/client/components/game/goal.test.js
+++ b/test/client/components/game/goal.test.js
@@ -7,13 +7,9 @@ import {MockSocket} from '../../../server/mocks/socket';
 import {DEBOUNCE_AMOUNT} from '../../../../client/constants/sockets';
 
 const socket = new MockSocket();
-const store = {
-  dispatch: stub()
-};
 
 const Goal = proxyquire('../../../../client/components/game/goal', {
-  '../../socket': {default: socket},
-  '../../store': {store}
+  '../../socket': {default: socket}
 }).default;
 
 const render = (props = {}) => shallow(<Goal frozen {...props}/>);
@@ -55,16 +51,16 @@ test('it emits the value to the server as you type', t => {
   clock.reset();
 });
 
-test('it updates the store with the new goal on input', t => {
+test('it updates the state with the new goal on input', t => {
   const wrapper = render({value: '', frozen: false});
 
   const value = 'Some goal';
   const input = wrapper.find('input');
+  const instance = wrapper.instance();
 
   input.simulate('input', {target: {value}, persist: () => {}});
 
-  t.true(store.dispatch.calledWith({
-    type: 'SET_PLAYER_INFO',
-    payload: {goal: value}
-  }));
+  const {state} = instance;
+
+  t.is(state.value, value);
 });

--- a/test/client/components/game/goal.test.js
+++ b/test/client/components/game/goal.test.js
@@ -1,7 +1,7 @@
 import test from 'ava';
 import React from 'react';
 import proxyquire from 'proxyquire';
-import sinon, {stub} from 'sinon';
+import sinon from 'sinon';
 import {shallow} from 'enzyme';
 import {MockSocket} from '../../../server/mocks/socket';
 import {DEBOUNCE_AMOUNT} from '../../../../client/constants/sockets';

--- a/test/client/components/game/name.test.js
+++ b/test/client/components/game/name.test.js
@@ -21,10 +21,10 @@ test('it renders the players name', t => {
   const name = wrapper.find('input[data-type="name"]');
 
   t.is(name.length, 1);
-  t.is(name.props().defaultValue, value);
+  t.is(name.props().value, value);
 });
 
-test('it updates the name on change, after a delay', t => {
+test('it sends the name to the server on update', t => {
   const clock = sinon.useFakeTimers();
 
   const value = 'new value';
@@ -41,4 +41,18 @@ test('it updates the name on change, after a delay', t => {
   }));
 
   clock.restore();
+});
+
+test('it updates the state with the new name on input', t => {
+  const wrapper = render({vlaue: 'Joe'});
+
+  const value = 'Some name';
+  const input = wrapper.find('input');
+  const instance = wrapper.instance();
+
+  input.simulate('input', {target: {value}, persist: () => {}});
+
+  const {state} = instance;
+
+  t.is(state.value, value);
 });

--- a/test/client/components/game/player-info.test.js
+++ b/test/client/components/game/player-info.test.js
@@ -11,7 +11,9 @@ const PlayerInfo = proxyquire('../../../../client/components/game/player-info', 
 const defaultProps = {
   name: 'Mr. Some Name',
   willpower: 10,
-  skills: JSON.stringify(['A', 'B', 'C']),
+  skill1: 'A',
+  skill2: 'B',
+  skill3: 'C',
   goal: 'Goal',
   points: 0,
   mode: 'PLAYING'
@@ -57,8 +59,16 @@ test('it renders a SkillList component', t => {
   const wrapper = render();
   const list = wrapper.find('SkillList');
 
+  const {skill1, skill2, skill3} = defaultProps;
+  const expected = {
+    frozen: undefined,
+    skill1,
+    skill2,
+    skill3
+  };
+
   t.is(list.length, 1);
-  t.deepEqual(list.props().items, defaultProps.skills);
+  t.deepEqual(list.props(), expected);
 });
 
 test('it does not render a Bidding component in SETUP mode', t => {

--- a/test/client/components/game/skill-list.test.js
+++ b/test/client/components/game/skill-list.test.js
@@ -1,19 +1,15 @@
 import test from 'ava';
 import React from 'react';
 import proxyquire from 'proxyquire';
-import sinon, {stub} from 'sinon';
+import sinon from 'sinon';
 import {shallow} from 'enzyme';
 import {MockSocket} from '../../../server/mocks/socket';
 import {DEBOUNCE_AMOUNT} from '../../../../client/constants/sockets';
 
 const socket = new MockSocket();
-const store = {
-  dispatch: stub()
-};
 
 const SkillList = proxyquire('../../../../client/components/game/skill-list', {
-  '../../socket': {default: socket},
-  '../../store': {store}
+  '../../socket': {default: socket}
 }).default;
 
 const render = (props = {}) => shallow(<SkillList frozen {...props}/>);
@@ -75,7 +71,7 @@ test('it emits the skill to the server on input', t => {
   }));
 });
 
-test('it updates the store with the new skill on input', t => {
+test('it updates the state with the new skill on input', t => {
   const items = ['', '', ''];
   const index = 0;
   const wrapper = render({items, frozen: false});
@@ -85,13 +81,12 @@ test('it updates the store with the new skill on input', t => {
   const input = lis.at(index).find('input');
 
   const value = 'abcde';
+  const expected = [...items];
+  expected[index] = value;
 
   input.simulate('input', {target: {value}, persist: () => {}});
 
-  t.true(store.dispatch.calledWith({
-    type: 'SET_PLAYER_INFO',
-    payload: {
-      [`skill${index + 1}`]: value
-    }
-  }));
+  const {state} = wrapper.instance();
+
+  t.deepEqual(state.items, expected);
 });

--- a/test/client/components/game/skill-list.test.js
+++ b/test/client/components/game/skill-list.test.js
@@ -90,3 +90,21 @@ test('it updates the state with the new skill on input', t => {
 
   t.deepEqual(state.items, expected);
 });
+
+test('it updates the state when the props are updated', t => {
+  const items = ['', '', ''];
+  const wrapper = render({items});
+
+  const instance = wrapper.instance();
+  const {items: oldItems} = instance.state;
+
+  t.deepEqual(oldItems, items);
+
+  const newItems = ['a', 'b', 'c'];
+  wrapper.setProps({items: newItems});
+  wrapper.update();
+
+  const {items: updatedItems} = instance.state;
+
+  t.deepEqual(updatedItems, newItems);
+});

--- a/test/client/components/game/skill-list.test.js
+++ b/test/client/components/game/skill-list.test.js
@@ -1,7 +1,7 @@
 import test from 'ava';
 import React from 'react';
 import proxyquire from 'proxyquire';
-import sinon from 'sinon';
+import sinon, {stub} from 'sinon';
 import {shallow} from 'enzyme';
 import {MockSocket} from '../../../server/mocks/socket';
 import {DEBOUNCE_AMOUNT} from '../../../../client/constants/sockets';
@@ -80,31 +80,36 @@ test('it updates the state with the new skill on input', t => {
   const lis = skills.find('li');
   const input = lis.at(index).find('input');
 
+  const instance = wrapper.instance();
+  instance.setState = stub();
+
   const value = 'abcde';
-  const expected = [...items];
-  expected[index] = value;
 
   input.simulate('input', {target: {value}, persist: () => {}});
 
-  const {state} = wrapper.instance();
-
-  t.deepEqual(state.items, expected);
+  // Not totally sure why enzyme isn't capturing the updated state, but this works
+  t.true(instance.setState.calledWith({
+    [`skill${index + 1}`]: value
+  }));
 });
 
 test('it updates the state when the props are updated', t => {
   const items = ['', '', ''];
   const wrapper = render({items});
 
-  const instance = wrapper.instance();
-  const {items: oldItems} = instance.state;
-
-  t.deepEqual(oldItems, items);
-
   const newItems = ['a', 'b', 'c'];
   wrapper.setProps({items: newItems});
   wrapper.update();
 
-  const {items: updatedItems} = instance.state;
+  const instance = wrapper.instance();
+  const {state} = instance;
+  const {ids} = state;
+  const expected = {
+    ids,
+    skill1: 'a',
+    skill2: 'b',
+    skill3: 'c'
+  };
 
-  t.deepEqual(updatedItems, newItems);
+  t.deepEqual(state, expected);
 });

--- a/test/client/components/game/skill-list.test.js
+++ b/test/client/components/game/skill-list.test.js
@@ -12,45 +12,58 @@ const SkillList = proxyquire('../../../../client/components/game/skill-list', {
   '../../socket': {default: socket}
 }).default;
 
-const render = (props = {}) => shallow(<SkillList frozen {...props}/>);
+const render = (props = {}) => shallow(<SkillList {...props}/>);
 
 test('it renders player skills', t => {
-  const items = ['a', 'b', 'c'];
-  const wrapper = render({items});
+  const props = {
+    skill1: 'a',
+    skill2: 'b',
+    skill3: 'c',
+    frozen: true
+  };
+  const wrapper = render(props);
   const skills = wrapper.find('[data-type="skills"]');
 
   t.is(skills.length, 1);
 
   const lis = skills.find('li');
-  t.is(lis.length, items.length);
+  t.is(lis.length, 3);
 
-  for (let i = 0; i < items.length; i++) {
+  for (let i = 0; i < 3; i++) {
     const li = lis.at(i);
 
-    t.is(li.text(), items[i]);
+    t.is(li.text(), props[`skill${i + 1}`]);
   }
 });
 
 test('it renders players skils as text boxes if editing is not frozen', t => {
-  const items = ['a', 'b', 'c'];
-  const wrapper = render({items, frozen: false});
+  const props = {
+    skill1: 'a',
+    skill2: 'b',
+    skill3: 'c'
+  };
+  const wrapper = render(props);
   const skills = wrapper.find('[data-type="skills"]');
   const lis = skills.find('li');
 
-  for (let i = 0; i < items.length; i++) {
+  for (let i = 0; i < 3; i++) {
     const li = lis.at(i);
     const input = li.find('input');
 
     t.is(input.length, 1);
-    t.is(input.props().value, items[i]);
+    t.is(input.props().value, props[`skill${i + 1}`]);
   }
 });
 
 test('it emits the skill to the server on input', t => {
   const clock = sinon.useFakeTimers();
 
-  const items = ['a', 'b', 'c'];
-  const wrapper = render({items, frozen: false});
+  const props = {
+    skill1: '',
+    skill2: '',
+    skill3: ''
+  };
+  const wrapper = render(props);
   const skills = wrapper.find('[data-type="skills"]');
   const lis = skills.find('li');
   const input = lis.at(0).find('input');
@@ -72,9 +85,13 @@ test('it emits the skill to the server on input', t => {
 });
 
 test('it updates the state with the new skill on input', t => {
-  const items = ['', '', ''];
+  const props = {
+    skill1: '',
+    skill2: '',
+    skill3: ''
+  };
   const index = 0;
-  const wrapper = render({items, frozen: false});
+  const wrapper = render(props);
 
   const skills = wrapper.find('[data-type="skills"]');
   const lis = skills.find('li');
@@ -94,11 +111,19 @@ test('it updates the state with the new skill on input', t => {
 });
 
 test('it updates the state when the props are updated', t => {
-  const items = ['', '', ''];
-  const wrapper = render({items});
+  const props = {
+    skill1: '',
+    skill2: '',
+    skill3: ''
+  };
+  const wrapper = render(props);
 
-  const newItems = ['a', 'b', 'c'];
-  wrapper.setProps({items: newItems});
+  const newProps = {
+    skill1: 'a',
+    skill2: 'b',
+    skill3: 'c'
+  };
+  wrapper.setProps(newProps);
   wrapper.update();
 
   const instance = wrapper.instance();


### PR DESCRIPTION
https://jira.kolya.cloud/browse/EIJ-38

- Rewrites `game/Name`, `game/SkillList`, and `game/Goal` to use the React state instead of updating the redux store via `SET_PLAYER_INFO` for each keypress
  - This is at the cost of using `this.setState` within `componentDidUpdate`, but a ticket will be opened to resolve this if possible. (Created [EIJ-53](https://jira.kolya.cloud/browse/EIJ-53))