### PR TITLE
[EIJ-52] Fix reconnect

### DIFF
--- a/client/constants/error-map.js
+++ b/client/constants/error-map.js
@@ -3,7 +3,8 @@
 export default {
   app: {
     unhandleException: 'An unknown error occured.',
-    socketDisconnect: 'You have been disconnected from the server.'
+    socketDisconnect: 'You have been disconnected from the server.',
+    timeout: 'There was a server side operation timeout.'
   },
   game: {
     doesntExist: 'The requested game doesn\'t exist.',

--- a/server/constants/index.js
+++ b/server/constants/index.js
@@ -7,4 +7,5 @@ export const rooms = {
 };
 
 export const POLL_INTERVAL = 250;
+export const SHORT_POLL_INTERVAL = 50;
 export const MAX_POLL_COUNT = 10;

--- a/server/constants/index.js
+++ b/server/constants/index.js
@@ -5,3 +5,6 @@ export const rooms = {
   PRIVATE: 'private',
   GAME: 'game'
 };
+
+export const POLL_INTERVAL = 250;
+export const MAX_POLL_COUNT = 10;

--- a/server/models/game.js
+++ b/server/models/game.js
@@ -78,8 +78,7 @@ export default class Game {
     const {prefix} = this.__STATICS__;
     player.assignRoom(rooms.GAME, `${prefix}/all`);
 
-    emit({
-      channel: player.rooms.private,
+    player.emitToMe({
       event: 'gameJoinSuccess',
       payload: this.id
     });

--- a/server/models/game.js
+++ b/server/models/game.js
@@ -2,7 +2,7 @@
 
 import Chance from 'chance';
 
-import {logInfo} from '../lib/logger';
+import {logInfo, logError} from '../lib/logger';
 import Slug from '../lib/slug';
 import * as GameModes from '../lib/game-mode';
 import {gameRepository, playerRepository} from '../repositories';
@@ -65,7 +65,7 @@ export default class Game {
     logInfo(`Game ${id} created by player ${owner.id}`);
   }
 
-  addPlayer(player: Player) {
+  async addPlayer(player: Player) {
     const {id} = player;
     const players = this.__players;
 
@@ -78,10 +78,14 @@ export default class Game {
     const {prefix} = this.__STATICS__;
     player.assignRoom(rooms.GAME, `${prefix}/all`);
 
-    player.emitGameJoinSuccess(this.id);
-    player.emitUpdate(false);
-    this.gmEmitPlayers();
-    this.emitGameMode(`player/${player.id}`);
+    try {
+      await player.emitGameJoinSuccess(this.id);
+      player.emitUpdate(false);
+      this.gmEmitPlayers();
+      this.emitGameMode(`player/${player.id}`);
+    } catch (error) {
+      logError(error);
+    }
   }
 
   gmInitGame() {

--- a/server/models/game.js
+++ b/server/models/game.js
@@ -78,11 +78,7 @@ export default class Game {
     const {prefix} = this.__STATICS__;
     player.assignRoom(rooms.GAME, `${prefix}/all`);
 
-    player.emitToMe({
-      event: 'gameJoinSuccess',
-      payload: this.id
-    });
-
+    player.emitGameJoinSuccess(this.id);
     player.emitUpdate(false);
     this.gmEmitPlayers();
     this.emitGameMode(`player/${player.id}`);

--- a/server/models/player.js
+++ b/server/models/player.js
@@ -27,7 +27,8 @@ type StaticsType = {
   name: string,
   disconnectTimer: ?TimeoutID,
   lastSerialized: {[string]: any},
-  rooms: RoomsType
+  rooms: RoomsType,
+  ready: boolean
 };
 
 export default class Player {
@@ -54,7 +55,8 @@ export default class Player {
       disconnectTimer: null,
       name,
       lastSerialized: {},
-      rooms: {}
+      rooms: {},
+      ready: false
     };
 
     this.assignRoom(rooms.PRIVATE, `player/${this.id}`);
@@ -65,6 +67,8 @@ export default class Player {
     this.destroyGame = this.destroyGame.bind(this);
 
     logInfo(`Player ${name} (${id}) created`);
+
+    this.__STATICS__.ready = true;
   }
 
   deactivate() {
@@ -132,6 +136,8 @@ export default class Player {
     for (const name of names) {
       this.assignRoom(name, rooms[name]);
     }
+
+    this.__STATICS__.ready = true;
   }
 
   get rooms(): RoomsType {
@@ -154,6 +160,7 @@ export default class Player {
   }
 
   reconnect() {
+    this.__STATICS__.ready = false;
     this.__STATICS__.active = true;
     this.__STATICS__.lastSerialized = {};
 
@@ -290,5 +297,9 @@ export default class Player {
     }
 
     return this.__STATICS__.name;
+  }
+
+  get ready(): boolean {
+    return this.__STATICS__.ready;
   }
 }

--- a/server/models/player.js
+++ b/server/models/player.js
@@ -159,7 +159,6 @@ export default class Player {
 
     clearTimeout(this.__STATICS__.disconnectTimer);
     this.rejoinRooms();
-    this.emitGameJoinSuccess(this.game.id);
   }
 
   destroy() {

--- a/server/models/player.js
+++ b/server/models/player.js
@@ -125,6 +125,15 @@ export default class Player {
     this.__STATICS__.rooms = {[rooms.PRIVATE]: privateRoom};
   }
 
+  rejoinRooms() {
+    const rooms = {...this.rooms};
+    const names = Object.keys(rooms);
+
+    for (const name of names) {
+      this.assignRoom(name, rooms[name]);
+    }
+  }
+
   get rooms(): RoomsType {
     return this.__STATICS__.rooms;
   }
@@ -149,6 +158,7 @@ export default class Player {
     this.__STATICS__.lastSerialized = {};
 
     clearTimeout(this.__STATICS__.disconnectTimer);
+    this.rejoinRooms();
     this.emitGameJoinSuccess(this.game.id);
   }
 

--- a/server/models/player.js
+++ b/server/models/player.js
@@ -358,20 +358,24 @@ export default class Player {
   }
 
   emitGameJoinSuccess(id: string, pollCount: number = 0) {
-    if (this.ready) {
-      logInfo(`Player ${this.id} successfully joined game ${id}`);
-      return this.emitToMe({
-        event: 'gameJoinSuccess',
-        payload: id
-      });
-    }
+    return new Promise(resolve => {
+      if (this.ready) {
+        logInfo(`Player ${this.id} successfully joined game ${id}`);
+        this.emitToMe({
+          event: 'gameJoinSuccess',
+          payload: id
+        });
 
-    if (pollCount === MAX_POLL_COUNT) {
-      logError(`Player ${this.id} not ready in time.`);
-      return this.emitTimeout();
-    }
+        return resolve();
+      }
 
-    setTimeout(() => this.emitGameJoinSuccess(id, pollCount + 1), POLL_INTERVAL);
+      if (pollCount === MAX_POLL_COUNT) {
+        logError(`Player ${this.id} not ready in time.`);
+        return this.emitTimeout();
+      }
+
+      setTimeout(() => this.emitGameJoinSuccess(id, pollCount + 1), POLL_INTERVAL);
+    });
   }
 
   emitTimeout() {

--- a/server/models/player.js
+++ b/server/models/player.js
@@ -149,6 +149,7 @@ export default class Player {
     this.__STATICS__.lastSerialized = {};
 
     clearTimeout(this.__STATICS__.disconnectTimer);
+    this.emitGameSuccess(this.game.id);
   }
 
   destroy() {
@@ -247,6 +248,13 @@ export default class Player {
     const channel = this.rooms.private;
 
     emit({channel, event, payload});
+  }
+
+  emitGameSuccess(id: string) {
+    this.emitToMe({
+      event: 'gameJoinSuccess',
+      payload: id
+    });
   }
 
   get id(): string {

--- a/server/models/player.js
+++ b/server/models/player.js
@@ -149,7 +149,7 @@ export default class Player {
     this.__STATICS__.lastSerialized = {};
 
     clearTimeout(this.__STATICS__.disconnectTimer);
-    this.emitGameSuccess(this.game.id);
+    this.emitGameJoinSuccess(this.game.id);
   }
 
   destroy() {
@@ -250,7 +250,7 @@ export default class Player {
     emit({channel, event, payload});
   }
 
-  emitGameSuccess(id: string) {
+  emitGameJoinSuccess(id: string) {
     this.emitToMe({
       event: 'gameJoinSuccess',
       payload: id

--- a/server/models/player.js
+++ b/server/models/player.js
@@ -347,8 +347,17 @@ export default class Player {
     }
   }
 
-  emitToMe({event, payload}: EmitType) {
+  emitToMe({event, payload}: EmitType, tries?: number = 0) {
     const channel = this.rooms.private;
+
+    if (tries === 10) {
+      logError(`Player ${this.id} not ready in time.`);
+      return this.emitTimeout();
+    }
+
+    if (!this.ready) {
+      return setTimeout(() => this.emitToMe({event, payload}, tries + 1), 50);
+    }
 
     emit({channel, event, payload});
   }

--- a/server/util/poller.js
+++ b/server/util/poller.js
@@ -1,0 +1,28 @@
+// @flow
+
+import {MAX_POLL_COUNT, SHORT_POLL_INTERVAL} from '../constants';
+
+type CheckFnType = () => boolean;
+
+const poller = (checkFn: CheckFnType) => {
+  let callCount = 0;
+
+  return new Promise((resolve, reject) => {
+    const poll = () => {
+      if (callCount === MAX_POLL_COUNT) {
+        return reject(new Error('Poll count exceeded.'));
+      }
+
+      if (checkFn()) {
+        resolve();
+      } else {
+        callCount += 1;
+        setTimeout(poll, SHORT_POLL_INTERVAL);
+      }
+    };
+
+    poll();
+  });
+};
+
+export default poller;

--- a/test/helpers/wait-for-call.js
+++ b/test/helpers/wait-for-call.js
@@ -1,0 +1,11 @@
+import poller from '../../server/util/poller';
+
+export const waitForCall = async (t, fn) => {
+  try {
+    await poller(() => fn.called);
+  } catch {
+    return t.fail(`Expected ${fn.name} to eventually be called but it was never called.`);
+  }
+
+  t.pass();
+};

--- a/test/server/mocks/socket.js
+++ b/test/server/mocks/socket.js
@@ -19,7 +19,12 @@ const stubEvent = (name, event, handler) => {
 export class MockSocket {
   playerId = null;
 
-  join = spy();
+  join = stub().callsFake((name, callback) => {
+    this.rooms[name] = name;
+    if (callback) {
+      callback();
+    }
+  });
 
   leave = spy();
 
@@ -34,6 +39,10 @@ export class MockSocket {
   });
 
   listen = stub().returns(this);
+
+  rooms = {}
+
+  connected = true
 
   __invoke = (name, event, data) => {
     const handler = stubCache[name];

--- a/test/server/models/game.test.js
+++ b/test/server/models/game.test.js
@@ -73,15 +73,12 @@ test('can add players', t => {
   t.is(game.players[1].id, players[1].id);
 });
 
-test('emits a `gameJoinSuccess` event to the players private room upon joining', t => {
+test('calls player.emitGameJoinSuccess upon joining', t => {
   const {game, player} = setup(true, false, false);
 
   game.addPlayer(player);
 
-  t.true(player.emitToMe.calledWith({
-    event: 'gameJoinSuccess',
-    payload: game.id
-  }));
+  t.true(player.emitGameJoinSuccess.calledWith(game.id));
 });
 
 test('cannot add duplicate players', t => {

--- a/test/server/models/game.test.js
+++ b/test/server/models/game.test.js
@@ -74,13 +74,11 @@ test('can add players', t => {
 });
 
 test('emits a `gameJoinSuccess` event to the players private room upon joining', t => {
-  const player = genPlayer();
-  const {game, emit} = setup(true, false, false);
+  const {game, player} = setup(true, false, false);
 
   game.addPlayer(player);
 
-  t.true(emit.calledWith({
-    channel: player.rooms.private,
+  t.true(player.emitToMe.calledWith({
     event: 'gameJoinSuccess',
     payload: game.id
   }));

--- a/test/server/models/game.test.js
+++ b/test/server/models/game.test.js
@@ -280,16 +280,16 @@ test('subtracts willpower from auction winner and enters playing mode', t => {
   t.is(game.mode, GameMode.PLAYING);
 });
 
-test('emits players to GM upon adding player to game', t => {
+test('emits players to GM upon adding player to game', async t => {
   const {game} = setup(true, true);
   const {player} = setup(false);
 
-  game.addPlayer(player);
+  await game.addPlayer(player);
 
   t.true(game.gmEmitPlayers.called);
 });
 
-test('#gmEmitPlayers emits players to GM', t => {
+test('#gmEmitPlayers emits players to GM', async t => {
   const {game, player: owner} = setup(true, true);
   const {player} = setup(false);
 
@@ -300,7 +300,7 @@ test('#gmEmitPlayers emits players to GM', t => {
     payload
   };
 
-  game.addPlayer(player);
+  await game.addPlayer(player);
 
   t.true(owner.emitToMe.calledWith(expected));
 });

--- a/test/server/models/player.test.js
+++ b/test/server/models/player.test.js
@@ -239,6 +239,21 @@ test('#reconnect calls #emitGameJoinSuccess', t => {
   clock.restore();
 });
 
+test('#reconnet calls #rejoinRooms', t => {
+  const {game, player} = setup();
+
+  gameRepository.find = stub().returns(game);
+
+  game.addPlayer(player);
+  const clock = sinon.useFakeTimers();
+
+  player.reconnect();
+
+  t.true(player.rejoinRooms.called);
+
+  clock.restore();
+});
+
 test('#destroyGame destroys the game they own, if one exists', t => {
   const {game, player} = setup(true, true);
 
@@ -424,4 +439,25 @@ test('#emitGameJoinSuccess emits a gameJoinSuccess event', t => {
     event: 'gameJoinSuccess',
     payload: id
   }));
+});
+
+test('#rejoinRooms rejoins the player to their rooms', t => {
+  const {game, player} = setup();
+
+  gameRepository.find = stub().returns(game);
+
+  game.addPlayer(player);
+  player.assignRoom.resetHistory();
+
+  const rooms = {...player.rooms};
+
+  player.rejoinRooms();
+
+  const roomNames = Object.keys(rooms);
+
+  for (const room of roomNames) {
+    t.true(player.assignRoom.calledWith(room, rooms[room]));
+  }
+
+  t.deepEqual(player.rooms, rooms);
 });

--- a/test/server/models/player.test.js
+++ b/test/server/models/player.test.js
@@ -224,21 +224,18 @@ test('has the discount timeout cleared if they return within the time allowed', 
   clock.restore();
 });
 
-test('#reconnect emits a game join success event', t => {
+test('#reconnect calls #emitGameJoinSuccess', t => {
   const {game, player} = setup();
 
   gameRepository.find = stub().returns(game);
 
   game.addPlayer(player);
-  player.emitToMe.resetHistory();
   const clock = sinon.useFakeTimers();
 
   player.reconnect();
 
-  t.true(player.emitToMe.calledWith({
-    event: 'gameJoinSuccess',
-    payload: game.id
-  }));
+  t.true(player.emitGameJoinSuccess.calledWith(game.id));
+
   clock.restore();
 });
 
@@ -415,4 +412,16 @@ test('#clearRooms removes the players from all game rooms', t => {
   }
 
   t.deepEqual(player.rooms, newRooms);
+});
+
+test('#emitGameJoinSuccess emits a gameJoinSuccess event', t => {
+  const {player} = setup();
+  const id = 'ABCDE';
+
+  player.emitGameJoinSuccess(id);
+
+  t.true(player.emitToMe.calledWith({
+    event: 'gameJoinSuccess',
+    payload: id
+  }));
 });

--- a/test/server/models/player.test.js
+++ b/test/server/models/player.test.js
@@ -224,6 +224,24 @@ test('has the discount timeout cleared if they return within the time allowed', 
   clock.restore();
 });
 
+test('#reconnect emits a game join success event', t => {
+  const {game, player} = setup();
+
+  gameRepository.find = stub().returns(game);
+
+  game.addPlayer(player);
+  player.emitToMe.resetHistory();
+  const clock = sinon.useFakeTimers();
+
+  player.reconnect();
+
+  t.true(player.emitToMe.calledWith({
+    event: 'gameJoinSuccess',
+    payload: game.id
+  }));
+  clock.restore();
+});
+
 test('#destroyGame destroys the game they own, if one exists', t => {
   const {game, player} = setup(true, true);
 

--- a/test/server/models/player.test.js
+++ b/test/server/models/player.test.js
@@ -224,21 +224,6 @@ test('has the discount timeout cleared if they return within the time allowed', 
   clock.restore();
 });
 
-test('#reconnect calls #emitGameJoinSuccess', t => {
-  const {game, player} = setup();
-
-  gameRepository.find = stub().returns(game);
-
-  game.addPlayer(player);
-  const clock = sinon.useFakeTimers();
-
-  player.reconnect();
-
-  t.true(player.emitGameJoinSuccess.calledWith(game.id));
-
-  clock.restore();
-});
-
 test('#reconnet calls #rejoinRooms', t => {
   const {game, player} = setup();
 

--- a/test/server/models/player.test.js
+++ b/test/server/models/player.test.js
@@ -395,7 +395,7 @@ test('#leaveGame calls #clearRooms', t => {
   t.true(player.clearRooms.called);
 });
 
-test('#clearRooms removes the players from all game rooms', t => {
+test('#clearRooms removes the players from all game rooms EXCEPT private', t => {
   const {player} = setup();
 
   const roomObj = {...player.rooms};
@@ -445,4 +445,36 @@ test('#rejoinRooms rejoins the player to their rooms', t => {
   }
 
   t.deepEqual(player.rooms, rooms);
+});
+
+test('player.ready is true after initialization', t => {
+  const {player} = setup();
+
+  t.true(player.ready);
+});
+
+test('#reconnect sets player.ready to false', t => {
+  const {game, player} = setup();
+  player.rejoinRooms = () => {};
+
+  gameRepository.find = stub().returns(game);
+
+  game.addPlayer(player);
+  const clock = sinon.useFakeTimers();
+
+  player.reconnect();
+
+  t.false(player.ready);
+
+  clock.restore();
+});
+
+test('#rejoinRooms sets player.ready to true after completing', t => {
+  const {player} = setup();
+
+  player.__STATICS__.ready = false;
+
+  player.rejoinRooms();
+
+  t.true(player.ready);
 });

--- a/test/server/socket/actions/join-game.test.js
+++ b/test/server/socket/actions/join-game.test.js
@@ -19,5 +19,8 @@ test('pings back an error if the game does not exist', t => {
   joinGame(socket, 'ABCDE');
 
   t.is(player.game, null);
-  t.true(player.emitToMe.calledWith('gameError', 'error.game.doesntExist'));
+  t.true(player.emitToMe.calledWith({
+    event: 'gameError',
+    payload: 'error.game.doesntExist'
+  }));
 });

--- a/test/server/stubs/create-socket.js
+++ b/test/server/stubs/create-socket.js
@@ -15,7 +15,8 @@ const methods = [
   'assignRoom',
   'emitToMe',
   'clearRooms',
-  'emitGameJoinSuccess'
+  'emitGameJoinSuccess',
+  'rejoinRooms'
 ];
 
 const gameMethods = [

--- a/test/server/stubs/create-socket.js
+++ b/test/server/stubs/create-socket.js
@@ -18,7 +18,8 @@ const methods = [
   'rejoinRooms',
   'waitForRooms',
   'hardEmit',
-  'emitTimeout'
+  'emitTimeout',
+  'emitGameJoinSuccess'
 ];
 
 const gameMethods = [

--- a/test/server/stubs/create-socket.js
+++ b/test/server/stubs/create-socket.js
@@ -15,7 +15,6 @@ const methods = [
   'assignRoom',
   'emitToMe',
   'clearRooms',
-  'emitGameJoinSuccess',
   'rejoinRooms',
   'waitForRooms',
   'hardEmit',

--- a/test/server/stubs/create-socket.js
+++ b/test/server/stubs/create-socket.js
@@ -14,7 +14,8 @@ const methods = [
   'emitUpdate',
   'assignRoom',
   'emitToMe',
-  'clearRooms'
+  'clearRooms',
+  'emitGameJoinSuccess'
 ];
 
 const gameMethods = [

--- a/test/server/stubs/create-socket.js
+++ b/test/server/stubs/create-socket.js
@@ -1,5 +1,5 @@
 import proxyquire from 'proxyquire';
-import {stub} from 'sinon';
+import sinon, {stub} from 'sinon';
 
 import {MockSocket} from '../mocks/socket';
 
@@ -16,7 +16,10 @@ const methods = [
   'emitToMe',
   'clearRooms',
   'emitGameJoinSuccess',
-  'rejoinRooms'
+  'rejoinRooms',
+  'waitForRooms',
+  'hardEmit',
+  'emitTimeout'
 ];
 
 const gameMethods = [
@@ -29,6 +32,13 @@ const gameMethods = [
   'gmInitGame',
   'emitToAll'
 ];
+
+const mockPromise = {
+  then: cb => {
+    cb();
+    return {catch: () => {}};
+  }
+};
 
 const stubAndCallThrough = (obj, func) => {
   const original = obj[func].bind(obj);
@@ -72,6 +82,8 @@ const setup = (createGame = true, playerIsOwner = false, joinToGame = true) => {
 
     socket.game = game;
   }
+
+  sinon.stub(player, 'waitForSocketConnection').returns(mockPromise);
 
   return {player, socket, game, emit};
 };

--- a/test/server/util/poller.test.js
+++ b/test/server/util/poller.test.js
@@ -1,0 +1,36 @@
+import test from 'ava';
+import proxyquire from 'proxyquire';
+import {stub} from 'sinon';
+
+const MAX_POLL_COUNT = 5;
+const poller = proxyquire('../../../server/util/poller', {
+  '../constants': {
+    MAX_POLL_COUNT,
+    SHORT_POLL_INTERVAL: 1
+  }
+}).default;
+
+test('resolves immediately if the check method is truthy', async t => {
+  const checkFn = stub().returns(true);
+
+  await poller(checkFn);
+  t.is(checkFn.callCount, 1);
+});
+
+test('resolves later if the polling takes a few tries', async t => {
+  const checkFn = stub().returns(false);
+  checkFn.onSecondCall().returns(true);
+
+  await poller(checkFn);
+  t.is(checkFn.callCount, 2);
+});
+
+test('rejects after the max poll count has been exceeded', async t => {
+  const checkFn = stub().returns(false);
+
+  try {
+    await poller(checkFn);
+  } catch {
+    return t.is(checkFn.callCount, MAX_POLL_COUNT);
+  }
+});


### PR DESCRIPTION
https://jira.kolya.cloud/browse/EIJ-52

- Ensure proper events are fired on reconnect
- Ensure rooms are rejoined on reconnect
- Adds a ready state to the player
- Makes sure that emit events are queued until the player is ready
- Adds polling utility method