### PR TITLE
Rolloff: In case of a tie, pick winner randomly

### DIFF
--- a/server/models/auction.js
+++ b/server/models/auction.js
@@ -38,18 +38,13 @@ export default class Auction {
 
   determineWinner = () => {
     const bids = this.bids.sort((a, b) => {
-      if (a.amount < b.amount) {
-        return 1;
-      }
-
-      if (a.amount > b.amount) {
-        return -1;
-      }
-
-      return 0;
+      return b - a;
     });
+    const winningAmount = bids[0].amount;
 
-    const {player: winner, amount} = bids[0];
+    const rolloffBids = bids.filter(bid => bid.amount === winningAmount);
+    const winnerIndex = Math.floor(Math.random() * rolloffBids.length);
+    const {player: winner, amount} = rolloffBids[winnerIndex];
 
     this.__STATICS__.game.endAuction(winner, amount);
   }

--- a/server/models/auction.js
+++ b/server/models/auction.js
@@ -38,7 +38,7 @@ export default class Auction {
 
   determineWinner = () => {
     const bids = this.bids.sort((a, b) => {
-      return b - a;
+      return b.amount - a.amount;
     });
     const winningAmount = bids[0].amount;
 

--- a/test/server/models/auction.test.js
+++ b/test/server/models/auction.test.js
@@ -44,3 +44,32 @@ test('determines winner after all bids placed', t => {
 
   t.true(game.endAuction.calledWith(players[1], 3));
 });
+
+function testRolloffRandomness(t, randomValue, expectedWinner) {
+  // Set up Math.random to return randomValue and then
+  // validate that the expectedWinner won
+  const realRandom = Math.random;
+  Math.random = () => randomValue;
+
+  const {game, players, auction} = genAuction();
+  game.endAuction = stub();
+
+  auction.bid(players[0], 2);
+  auction.bid(players[1], 2);
+  auction.bid(players[2], 2);
+
+  t.true(game.endAuction.calledWith(players[expectedWinner], 2));
+  Math.random = realRandom;
+}
+
+test('Ties should be resolved based on Math.random (greatest)', t => {
+  testRolloffRandomness(t, 0.99, 2);
+});
+
+test('Ties should be resolved based on Math.random (lowest)', t => {
+  testRolloffRandomness(t, 0, 0);
+});
+
+test('Ties should be resolved based on Math.random (middle)', t => {
+  testRolloffRandomness(t, 0.5, 1);
+});


### PR DESCRIPTION
All modern JavaScript implementations use stable sorts. This means
that relative ordering of equal items is maintained.

The previous implementation of the bidding was sorting the bids and
then picking the first element. In cases of ties, this results in the
first item in the array with that amount always being picked. The correct solution
is to pick randomly between the players with the same bid.

Note that to test this locally I had to make a few changes I did not add here:

- Update express-to-koa to 1.2.0
- Remove .npmrc and change all fortawesome pro references to free versions

For reference those changes can be found at this commit: https://github.com/azeemba/everyoneisjohn/commit/897410ca54dd1ed41cef2b8c1af1ad18c23752a4